### PR TITLE
Support additional 2p file formats through haussio

### DIFF
--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -4,6 +4,11 @@ from suite2p import register, dcnv, classifier, utils
 from suite2p import celldetect2 as celldetect2
 from scipy import stats, io, signal
 from multiprocessing import Pool
+try:
+    from haussmeister import haussio
+    HAS_HAUS = True
+except ImportError:
+    HAS_HAUS = False
 
 def tic():
     return time.time()
@@ -107,8 +112,17 @@ def run_s2p(ops={},db={}):
             ops1 = utils.h5py_to_binary(ops)
             print('time %4.4f. Wrote h5py to binaries for %d planes'%(toc(i0), len(ops1)))
         else:
-            ops1 = utils.tiff_to_binary(ops)
-            print('time %4.4f. Wrote tifs to binaries for %d planes'%(toc(i0), len(ops1)))
+            try:
+                ops1 = utils.tiff_to_binary(ops)
+                print('time %4.4f. Wrote tifs to binaries for %d planes'%(toc(i0), len(ops1)))
+            except Exception as e:
+                if HAS_HAUS:
+                    dataset = haussio.load_haussio(ops['data_path'][0])
+                    ops1 = dataset.tosuite2p(ops)
+                    print('time %4.4f. Wrote data to binaries for %d planes'%(toc(i0), len(ops1)))
+                else:
+                    print('Unsupported file format: ' + e.message)
+                    return
         # save ops1
         np.save(fpathops1, ops1)
     if not ops['do_registration']:


### PR DESCRIPTION
Add support for native non-tiff PrairieView and ThorLabs data sets if haussmeister.haussio is available. The file format is automatically detected by [`haussio.load_haussio`](https://github.com/neurodroid/haussmeister/blob/master/haussmeister/haussio.py#L1381). Support for ScanImage4 and Doric Studio could be added, but they are not automatically detected at this time.