### PR TITLE
Fixed bug when empty cells are in sourcery/get_stat

### DIFF
--- a/suite2p/sourcery.py
+++ b/suite2p/sourcery.py
@@ -217,7 +217,12 @@ def get_stat(ops, stat, Ucell, codes):
     d0 = d0.astype('float32')
     rs    = rs[rs<=1.]
     frac = 0.5
+
+    # Remove empty cells
+    stat = [elem for elem in stat if len(elem['ypix']) != 0]
     ncells = len(stat)
+    print(ncells)
+
     footprints = np.zeros((ncells,))
     for k in range(0,ncells):
         stat0 = stat[k]


### PR DESCRIPTION
suite2p was throwing an error in get_stat when some ROIs contain no pixels.