### PR TITLE
HDF5 files are now recognized as .h5 format files.

### DIFF
--- a/suite2p/io/utils.py
+++ b/suite2p/io/utils.py
@@ -7,6 +7,9 @@ def list_h5(ops):
     froot = os.path.dirname(ops['h5py'])
     lpath = os.path.join(froot, "*.h5")
     fs = natsorted(glob.glob(lpath))
+    lpath = os.path.join(froot, "*.hdf5")
+    fs2 = natsorted(glob.glob(lpath))
+    fs.extend(fs2)
     return fs
 
 def list_tifs(froot, look_one_level_down):


### PR DESCRIPTION
HDF5 files were not recognized as valid a .h5 file format. This fix searches for .hdf5 files created using the h5py library. 