### PR TITLE
Added frames_per_file field to tiff_to_binary

### DIFF
--- a/suite2p/io/tiff.py
+++ b/suite2p/io/tiff.py
@@ -183,6 +183,7 @@ def tiff_to_binary(ops):
             for j in range(0,nplanes):
                 if ik==0 and ix==0:
                     ops1[j]['nframes'] = 0
+                    ops1[j]['frames_per_file'] = np.zeros((len(fs),), dtype=int)
                     ops1[j]['meanImg'] = np.zeros((im.shape[1], im.shape[2]), np.float32)
                     if nchannels>1:
                         ops1[j]['meanImg_chan2'] = np.zeros((im.shape[1], im.shape[2]), np.float32)
@@ -195,6 +196,7 @@ def tiff_to_binary(ops):
 
                 reg_file[j].write(bytearray(im2write))
                 ops1[j]['nframes'] += im2write.shape[0]
+                ops1[j]['frames_per_file'][ik] += im2write.shape[0]
                 ops1[j]['frames_per_folder'][which_folder] += im2write.shape[0]
                 #print(ops1[j]['frames_per_folder'][which_folder])
                 if nchannels>1:


### PR DESCRIPTION
This field preserves the functionality of the frames_per_folder field even when not using the look_one_level_down flag. Currently I've only added this to tiff_to_binary (as that's all we use) but it could be added to the other x_to_binary functions if they handle files in the same way.