### PR TITLE
handle sbx files with unidirectional scanning directly from the gui

### DIFF
--- a/suite2p/gui/rungui.py
+++ b/suite2p/gui/rungui.py
@@ -209,7 +209,7 @@ class RunWindow(QtGui.QDialog):
         qlabel.setToolTip('File format (selects which parser to use)')
         self.layout.addWidget(qlabel,1,0,1,1)
         self.inputformat = QtGui.QComboBox()
-        [self.inputformat.addItem(f) for f in ['tif','bruker','sbx', 'h5','mesoscan','haus','sbx']]
+        [self.inputformat.addItem(f) for f in ['tif','bruker','sbx', 'h5','mesoscan','haus']]
         self.inputformat.currentTextChanged.connect(self.parse_inputformat)
         self.layout.addWidget(self.inputformat,2,0,1,1)
 
@@ -330,7 +330,6 @@ class RunWindow(QtGui.QDialog):
         self.f = 0
         self.compile_ops_db()
         L = len(self.opslist)
-        print(self.ops['lines'])
         np.save('ops%d.npy'%L, self.ops)
         np.save('db%d.npy'%L, self.db)
         self.opslist.append('ops%d.npy'%L)

--- a/suite2p/io/sbx.py
+++ b/suite2p/io/sbx.py
@@ -31,15 +31,17 @@ def sbx_get_shape(sbxfile):
         chan = 1
     elif chan == 3:
         chan = 1
-    max_idx = os.path.getsize(sbxfile)/nrows/ncols/chan/2
+    max_idx = fsize/nrows/ncols/chan/2
     if max_idx != info.config.frames:
-        raise(Warning('sbx filesize doesnt match mat [{0},{1}]'.format(
-                    max_idx,
-                    info.config.frames)))
+        print('SBX filesize doesnt match accompaning MAT [{0},{1}]. Check recording.'.format(
+            max_idx,
+            info.config.frames))
     nplanes = 1
     if not isinstance(info.otwave,int):
         if len(info.otwave) and info.volscan:
             nplanes = len(info.otwave)
+    # make sure that if there are multiple planes it works regardless of the number of recorded  frames
+    max_idx = np.floor((max_idx/nplanes)) * nplanes
     return (int(chan),int(ncols),int(nrows),int(max_idx)),nplanes
 
 def sbx_memmap(filename,plane_axis=True):

--- a/suite2p/io/sbx.py
+++ b/suite2p/io/sbx.py
@@ -97,21 +97,24 @@ def sbx_to_binary(ops,ndeadcols = -1):
     nchannels = ops1[0]['nchannels']
     # open all binary files for writing
     ops1, sbxlist, reg_file, reg_file_chan2 = utils.find_files_open_binaries(ops1)
-    print(sbxlist)
     iall = 0
     for j in range(ops1[0]['nplanes']):
         ops1[j]['nframes_per_folder'] = np.zeros(len(sbxlist), np.int32)
-    print(sbxlist)
     ik = 0
     if 'sbx_ndeadcols' in ops1[0].keys():
         ndeadcols = int(ops1[0]['sbx_ndeadcols'])
     if ndeadcols == -1:
-        # compute dead cols from the first file
-        tmpsbx = sbx_memmap(sbxlist[0])
-        colprofile = np.mean(tmpsbx[0][0][0],axis = 0)
-        ndeadcols = np.argmax(np.diff(colprofile)) + 1
-        print('Removing {0} dead columns while loading sbx data.'.format(ndeadcols))
-        del tmpsbx
+        sbxinfo = sbx_get_info(sbxlist[0])
+        if sbxinfo.scanmode == 1:
+            # do not remove dead columns in unidirectional scanning mode
+            ndeadcols = 0
+        else:
+            # compute dead cols from the first file
+            tmpsbx = sbx_memmap(sbxlist[0])
+            colprofile = np.mean(tmpsbx[0][0][0],axis = 0)
+            ndeadcols = np.argmax(np.diff(colprofile)) + 1
+            del tmpsbx
+            print('Removing {0} dead columns while loading sbx data.'.format(ndeadcols))
     ops1[0]['sbx_ndeadcols'] = ndeadcols
     
     for ifile,sbxfname in enumerate(sbxlist):


### PR DESCRIPTION
This is related to #287. This solution assumes that this only happens for files recorded using a specific scanning mode. Another solution is to expose sbx_ndeadcols in the GUI so that the user can specify the value manually. I prefer keeping this out of the GUI unless needed because it is used only for sbx files.

Summary:
- Check scanmode ~= 1 for sbx before computing sbx_ndeadcols if -1.
- Removed duplicate sbx entry on the GUI menu.
- Removed file path print on sbx load.
- Removed ops['lines'] print on GUI add_ops (was causing GUI crash).