### PR TITLE
Minor: Pyqtgraph update to remove deprecation warnings

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,9 @@ dependencies:
   - h5py
   - scikit-learn
   - pyqt
-  - pyqtgraph
   - natsort
   - pip:
+    - pyqtgraph==0.11.0rc
     - rastermap>0.1.0
     - tifffile
     - scanimage-tiff-reader

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -12,9 +12,9 @@ dependencies:
   - h5py
   - scikit-learn
   - pyqt
-  - pyqtgraph
   - natsort
   - pip:
+    - pyqtgraph==0.11.0rc
     - rastermap>0.1.0
     - tifffile
     - scanimage-tiff-reader


### PR DESCRIPTION
Hi,

Python was showing deprecation warnings whenever Pyqtgraph was called, something they resolved in their update some months ago.  While Pyqtgraph 0.11 hasn't been released yet, the release candidate seems to work fine for suite2p, so this pull request just adds it to the environment.yml files.  Besides cleaning up the output during tests and for suite2p library users, it will keep suite2p compatible with Python 3.8.

Best wishes,

Nick

