### PR TITLE
Downloads test_data and changes to test comparison methods.

### DIFF
--- a/suite2p/utils.py
+++ b/suite2p/utils.py
@@ -3,10 +3,12 @@ import numpy as np
 from natsort import natsorted
 import math, time
 import glob, h5py, os, json
-from scipy import signal
 from scipy import stats, signal
-from scipy.sparse import linalg
-import scipy.io
+from tqdm import tqdm
+from urllib.request import urlopen
+import tempfile
+import shutil
+
 
 def boundary(ypix,xpix):
     """ returns pixels of mask that are on the exterior of the mask """
@@ -177,3 +179,42 @@ def get_frames(ops, ix, bin_file, crop=False, badframes=False):
             else:
                 mov[i,:,:] = data
     return mov
+
+
+def download_url_to_file(url, dst, progress=True):
+    r"""Download object at the given URL to a local path.
+            Thanks to torch, slightly modified
+    Args:
+        url (string): URL of the object to download
+        dst (string): Full path where object will be saved, e.g. `/tmp/temporary_file`
+        progress (bool, optional): whether or not to display a progress bar to stderr
+            Default: True
+    """
+    file_size = None
+    u = urlopen(url)
+    meta = u.info()
+    if hasattr(meta, 'getheaders'):
+        content_length = meta.getheaders("Content-Length")
+    else:
+        content_length = meta.get_all("Content-Length")
+    if content_length is not None and len(content_length) > 0:
+        file_size = int(content_length[0])
+    # We deliberately save it in a temp file and move it after
+    dst = os.path.expanduser(dst)
+    dst_dir = os.path.dirname(dst)
+    f = tempfile.NamedTemporaryFile(delete=False, dir=dst_dir)
+    try:
+        with tqdm(total=file_size, disable=not progress,
+                  unit='B', unit_scale=True, unit_divisor=1024) as pbar:
+            while True:
+                buffer = u.read(8192)
+                if len(buffer) == 0:
+                    break
+                f.write(buffer)
+                pbar.update(len(buffer))
+        f.close()
+        shutil.move(f.name, dst)
+    finally:
+        f.close()
+        if os.path.exists(f.name):
+            os.remove(f.name)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,13 +1,69 @@
 import pytest
 import shutil
 import filecmp
-import os
+import sys
+from pathlib import Path
 from suite2p import run_s2p
+from typing import Tuple, Iterable
+from suite2p.utils import download_url_to_file
 
-# TODO: store as env variables?
-root_path = '/Users/chriski/Desktop/suite2p_ws'
-gt_path = root_path + '/chris_output'  # Ground Truth path
-img_path = root_path + '/images_ex'  # Input Images path
+
+# Paths to .suite2p dir and .suite2p test_data dir
+suite_dir = Path.home().joinpath('.suite2p')
+test_data_dir = suite_dir.joinpath('test_data')
+
+
+def get_test_data_filenames(tups_of_plane_chans: Iterable[Tuple[int, int]]):
+    """
+    Returns list of test_data filenames associated with given list of tuples of num_planes and num_channels.
+
+    Parameters
+    ----------
+    tups_of_plane_chans: list
+        each element is a tuple corresponding to one set of test data. First element is number of planes and
+        second element is number of channels.
+
+    Returns
+    -------
+
+    all_files: list
+        one list that contains all requested test_data filenames.
+
+    """
+    all_files = []
+    for num_planes, num_chans in tups_of_plane_chans:
+        outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat']
+        if num_chans == 2:
+            outputs_to_check.extend(['F_chan2', 'Fneu_chan2','redcell'])
+        for i in range(num_planes):
+            for out in outputs_to_check:
+                file_name = "{0}plane{1}chan_{2}_plane{3}.npy".format(num_planes, num_chans, out, i)
+                all_files.append(file_name)
+    return all_files
+
+
+def download_test_data():
+    """
+    Downloads input_data and all ground_truth/test data (1 plane 1 channel, 2 planes 1 channel,
+    and 2 planes 2 channel)
+
+    Returns
+    -------
+
+    """
+    # Make test_data dir if doesn't exist
+    suite_dir.mkdir(exist_ok=True)
+    test_data_dir.mkdir(exist_ok=True)
+    td_root_url = 'http://www.suite2p.org/test_data/'
+    files_to_get = ['input0.tif', 'input1.tif']
+    # Get test_data for 1 plane 1 channel, 2 planes 1 channel, and 2 planes 2 channel
+    files_to_get.extend(get_test_data_filenames([(1, 1), (2, 1), (2, 2)]))
+    for fn in files_to_get:
+        data_url = td_root_url + fn
+        cached_file = test_data_dir.joinpath(fn)
+        if not cached_file.exists():
+            sys.stderr.write('Downloading: "{}" to {}\n'.format(data_url, cached_file))
+            download_url_to_file(data_url, str(cached_file), progress=True)
 
 
 @pytest.fixture()
@@ -17,10 +73,12 @@ def setup_and_teardown(tmpdir):
     each test. Then, removes temporary directory after test is completed.
     """
     ops = run_s2p.default_ops()
-    ops['data_path'] = [img_path]
+    download_test_data()
+    ops['data_path'] = [test_data_dir]
     ops['save_path0'] = str(tmpdir)
     yield ops, str(tmpdir)
-    if os.path.isdir(tmpdir):
+    tmpdir_path = Path(str(tmpdir))
+    if tmpdir_path.is_dir():
         shutil.rmtree(tmpdir)
         print('Successful removal of tmp_path {}.'.format(tmpdir))
 
@@ -30,24 +88,24 @@ class TestCommonPipelineUseCases:
     Class that tests common use cases for pipeline.
     """
 
-    def check_output_gt(self, output_root, gt_root, nplanes: int, nchannels: int):
+    def check_output_gt(self, output_root, nplanes: int, nchannels: int):
         """
         Helper function to check if outputs given by a test are exactly the same
         as the ground truth outputs.
         """
-        gt_dir = os.path.join(str(gt_root), "{}plane{}chan".format(nplanes, nchannels))
-        output_dir = os.path.join(str(output_root), "suite2p")
-        outputs_to_check = ['F.npy', 'Fneu.npy', 'iscell.npy', 'spks.npy', 'stat.npy', 'data.bin']
+        output_dir = Path(output_root).joinpath("suite2p")
+        # Output has different structure from test_data structure
+        outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat']
         # Check channel2 outputs if necessary
         if nchannels == 2:
-            outputs_to_check.extend(['F_chan2.npy', 'Fneu_chan2.npy', 'data_chan2.bin'])
+            outputs_to_check.extend(['F_chan2', 'Fneu_chan2'])
         # Go through each plane folder and compare contents
         for i in range(nplanes):
             for output in outputs_to_check:
                 # Non-shallow comparison of both files to make sure their contents are identical
                 assert filecmp.cmp(
-                    os.path.join(gt_dir, 'plane{}'.format(i), output),
-                    os.path.join(output_dir, 'plane{}'.format(i), output),
+                    test_data_dir.joinpath('{0}plane{1}chan_{2}_plane{3}.npy'.format(nplanes, nchannels, output, i)),
+                    output_dir.joinpath('plane{}'.format(i), "{}.npy".format(output)),
                     shallow=False
                 )
 
@@ -59,7 +117,7 @@ class TestCommonPipelineUseCases:
         ops, tmp_dir = setup_and_teardown
         run_s2p.run_s2p(ops=ops)
         # Check outputs against ground_truth files
-        self.check_output_gt(tmp_dir, gt_path, ops['nplanes'], ops['nchannels'])
+        self.check_output_gt(tmp_dir, ops['nplanes'], ops['nchannels'])
 
     def test_2plane_1chan(self, setup_and_teardown):
         """
@@ -68,7 +126,7 @@ class TestCommonPipelineUseCases:
         ops, tmp_dir = setup_and_teardown
         ops['nplanes'] = 2
         run_s2p.run_s2p(ops=ops)
-        self.check_output_gt(tmp_dir, gt_path, ops['nplanes'], ops['nchannels'])
+        self.check_output_gt(tmp_dir, ops['nplanes'], ops['nchannels'])
 
     def test_2plane_2chan(self, setup_and_teardown):
         """
@@ -78,4 +136,4 @@ class TestCommonPipelineUseCases:
         ops['nplanes'] = 2
         ops['nchannels'] = 2
         run_s2p.run_s2p(ops=ops)
-        self.check_output_gt(tmp_dir, gt_path, ops['nplanes'], ops['nchannels'])
+        self.check_output_gt(tmp_dir, ops['nplanes'], ops['nchannels'])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -66,7 +66,7 @@ def download_test_data():
             download_url_to_file(data_url, str(cached_file), progress=True)
 
 
-def compare_npy_arrays(arr1, arr2, atol):
+def compare_npy_arrays(arr1, arr2, rtol, atol):
     """
     Compares contents of two numpy arrays. Checks that the elements are within an absolute tolerance of 0.008.
 
@@ -88,10 +88,12 @@ def compare_npy_arrays(arr1, arr2, atol):
             output_curr_dict = arr2[i]
             # Iterate through keys and make sure values are same
             for k in gt_curr_dict.keys():
-                assert np.allclose(gt_curr_dict[k], output_curr_dict[k], rtol=0, atol=atol)
+                assert np.allclose(gt_curr_dict[k], output_curr_dict[k], rtol=rtol, atol=atol)
     # Assume all other cases have arrays that contain numbers
     else:
-        assert np.allclose(arr1, arr2, rtol=0, atol=atol)
+        print("Max Absolute diff is : {}".format(np.max(np.abs(arr1-arr2))))
+        print("Min rtol*(abs(arr2)) is : {}".format(np.min(rtol*np.abs(arr2))))
+        assert np.allclose(arr1, arr2, rtol=rtol, atol=atol)
 
 
 @pytest.fixture()
@@ -109,8 +111,7 @@ def setup_and_teardown(tmpdir):
     if tmpdir_path.is_dir():
         shutil.rmtree(tmpdir)
         print('Successful removal of tmp_path {}.'.format(tmpdir))
-
-
+    
 class TestCommonPipelineUseCases:
     """
     Class that tests common use cases for pipeline.
@@ -138,7 +139,8 @@ class TestCommonPipelineUseCases:
                 output_data = np.load(
                     str(output_dir.joinpath('plane{}'.format(i), "{}.npy".format(output))), allow_pickle=True
                 )
-                compare_npy_arrays(test_data, output_data, 0.008)
+                print("Comparing {} for plane {}".format(output, i))
+                compare_npy_arrays(test_data, output_data, rtol=1e-6, atol=5e-2)
 
     def test_1plane_1chan(self, setup_and_teardown):
         """


### PR DESCRIPTION
List of changes included in this PR:

- Added Cellpose/utils' `download_url_to_file` function to `suite2p/utils.py`. Removed some unused imports and added tqdm import.
- Downloads test_data files to `.suite2p` folder
- Tests now rely on `Pathlib` instead of `os.path`
- Changed from using `filecmp.cmp` to `np.allclose` for comparison of `.npy` output files. Although `filecmp.cmp` worked fine when I kept running the tests on my own machine, the tests failed when I ran them on my remote workstation and another machine I had at home (both are Linux machines). The tests fail because all the output numpy arrays have very small differences. 
For instance, this example involves the comparison of the ground_truth(calculated on my machine) `F.npy` and the test_generated (on Janelia's remote workstation) `F.npy`. 
```
# Ground Truth F.npy data
arr1 = array([[17830.232, 17694.783, 17795.121, ..., 17561.602, 17491.295,
        17596.104],
       [17949.002, 17597.898, ...    16840.107],
       [17208.02 , 17385.795, 17578.523, ..., 17569.71 , 17490.918,
        17605.947]], dtype=float32)

# Test_generated F.npy Data
arr2 = array([[17830.23 , 17694.781, 17795.121, ..., 17561.602, 17491.295,
        17596.105],
       [17949.002, 17597.896, ...    16840.107],
       [17208.02 , 17385.797, 17578.531, ..., 17569.71 , 17490.918,
        17605.947]], dtype=float32)
```
I also noticed that the `F.npy` produced on my machine at home showed similar differences to the ground_truth `F.npy` **but** was not the same as the `F.npy` produced on Janelia's remote workstation. This leads me to believe there are small machine-specific differences across the output files which makes `filecmp.cmp` hard to use.

This problem was resolved with np.allclose and choosing appropriate `rtol` (relative tolerance) and `atol` (absolute tolerance) values. 