### PR TITLE
Detection/Extraction & Classification regression tests added.

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -14,3 +14,12 @@
 /tmp
 /tmp
 /tmp
+/tmp
+/tmp
+/tmp
+/tmp
+/tmp
+/tmp
+/tmp
+/tmp
+/tmp

--- a/data/test_data/classification/pre_stat.npy.dvc
+++ b/data/test_data/classification/pre_stat.npy.dvc
@@ -1,0 +1,7 @@
+md5: 222804786d99bbeef0d10a4c1c7c21e2
+outs:
+- md5: 144484cd1e07eff62abee5f683847558
+  path: pre_stat.npy
+  cache: true
+  metric: false
+  persist: false

--- a/data/test_data/detection/meanImg_chan2p0.npy.dvc
+++ b/data/test_data/detection/meanImg_chan2p0.npy.dvc
@@ -1,0 +1,7 @@
+md5: 5b9422aef421f9d4c80962df49852160
+outs:
+- md5: 4715f1d85a2834e85fa4f3619588ef8a
+  path: meanImg_chan2p0.npy
+  cache: true
+  metric: false
+  persist: false

--- a/data/test_data/detection/meanImg_chan2p1.npy.dvc
+++ b/data/test_data/detection/meanImg_chan2p1.npy.dvc
@@ -1,0 +1,7 @@
+md5: 6b6c9ea51effd7491654afa411cfa072
+outs:
+- md5: 3b4f25de658ee8b0e7073a562b3ac04c
+  path: meanImg_chan2p1.npy
+  cache: true
+  metric: false
+  persist: false

--- a/data/test_data/detection/pre_registered01.npy.dvc
+++ b/data/test_data/detection/pre_registered01.npy.dvc
@@ -1,0 +1,7 @@
+md5: 9440c5f295a4bf4cad4c3f8b6d568856
+outs:
+- md5: 1bc65d48d14cf70d611ba56e7619f638
+  path: pre_registered01.npy
+  cache: true
+  metric: false
+  persist: false

--- a/data/test_data/detection/pre_registered02.npy.dvc
+++ b/data/test_data/detection/pre_registered02.npy.dvc
@@ -1,0 +1,7 @@
+md5: a72a05da232bb5b83cc03e5366d3ec63
+outs:
+- md5: 9e938c10bfe7b4e5e686df5f1be4d023
+  path: pre_registered02.npy
+  cache: true
+  metric: false
+  persist: false

--- a/data/test_data/detection/pre_registered11.npy.dvc
+++ b/data/test_data/detection/pre_registered11.npy.dvc
@@ -1,0 +1,7 @@
+md5: 76390e0b782976e5aa48b6db5ae39a49
+outs:
+- md5: 972a12cb1f7f9a879e03df7cab086fb5
+  path: pre_registered11.npy
+  cache: true
+  metric: false
+  persist: false

--- a/data/test_data/detection/pre_registered12.npy.dvc
+++ b/data/test_data/detection/pre_registered12.npy.dvc
@@ -1,0 +1,7 @@
+md5: 266854da281be5f3f81babae0fc573a8
+outs:
+- md5: 2c4f7401bbcf8855d1571d67cf75b704
+  path: pre_registered12.npy
+  cache: true
+  metric: false
+  persist: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ class TestUtils:
     """
 
     @staticmethod
-    def create_plane_dir(op, plane):
+    def get_plane_dir(op, plane):
         suite_dir = Path(op['save_path0']).joinpath('suite2p')
         suite_dir.mkdir(exist_ok=True)
         plane_dir = Path(op['save_path0']).joinpath('suite2p').joinpath('plane{}'.format(plane))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,15 +12,27 @@ class TestUtils:
     """
 
     @staticmethod
-    def check_output(output_root, test_data_dir, nplanes: int, nchannels: int):
+    def create_plane_dir(op, plane):
+        suite_dir = Path(op['save_path0']).joinpath('suite2p')
+        suite_dir.mkdir(exist_ok=True)
+        plane_dir = Path(op['save_path0']).joinpath('suite2p').joinpath('plane{}'.format(plane))
+        plane_dir.mkdir(exist_ok=True)
+        return plane_dir
+
+    @staticmethod
+    def write_data_to_binary(binary_path, data_path):
+        input_data = np.load(data_path)
+        with open(binary_path, 'wb') as f:
+            input_data.tofile(f)
+        return binary_path
+
+    @staticmethod
+    def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int, nchannels: int):
         """
         Helper function to check if outputs given by a test are exactly the same
         as the ground truth outputs.
         """
         output_dir = Path(output_root).joinpath("suite2p")
-        outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat']
-        if nchannels == 2:
-            outputs_to_check.extend(['F_chan2', 'Fneu_chan2'])
         for i in range(nplanes):
             for output in outputs_to_check:
                 test_data = np.load(

--- a/tests/test_modules/test_classification_module.py
+++ b/tests/test_modules/test_classification_module.py
@@ -17,4 +17,4 @@ class TestSuite2pClassificationModule:
         iscell = classification.Classifier(default_cls_file, keys=['npix_norm', 'compact', 'skew']).run(stat)
         expected_output = np.load(get_test_dir_path.joinpath('1plane1chan', 'suite2p', 'plane0', 'iscell.npy'))
         # Logistic Regression has differences in tolerance due to depndence on C
-        assert np.allclose(iscell, expected_output, atol=1e-4)
+        assert np.allclose(iscell, expected_output, atol=2e-4)

--- a/tests/test_modules/test_classification_module.py
+++ b/tests/test_modules/test_classification_module.py
@@ -1,5 +1,5 @@
 import numpy as np
-import suite2p
+from suite2p import classification
 
 
 class TestSuite2pClassificationModule:

--- a/tests/test_modules/test_classification_module.py
+++ b/tests/test_modules/test_classification_module.py
@@ -1,10 +1,19 @@
 import numpy as np
+from pathlib import Path
 from suite2p import classification
 
 
 class TestSuite2pClassificationModule:
     """
-    Tests for the Suite2p Classification module
+    Tests for the Suite2p Classification module.
     """
-    def test_classification_module_input_output(self, setup_and_teardown, get_test_dir_path):
-        pass
+    def test_classification_output(self, setup_and_teardown, get_test_dir_path):
+        """
+        Regression test that checks the output of classification.
+        """
+        op, tmp_dir = setup_and_teardown
+        default_cls_file = get_test_dir_path.parent.parent.joinpath('suite2p', 'classifiers', 'classifier.npy')
+        stat = np.load(get_test_dir_path.joinpath('classification', 'pre_stat.npy'), allow_pickle=True)
+        iscell = classification.Classifier(default_cls_file, keys=['npix_norm', 'compact', 'skew']).run(stat)
+        expected_output = np.load(get_test_dir_path.joinpath('1plane1chan', 'suite2p', 'plane0', 'iscell.npy'))
+        assert np.array_equal(iscell, expected_output)

--- a/tests/test_modules/test_classification_module.py
+++ b/tests/test_modules/test_classification_module.py
@@ -16,4 +16,5 @@ class TestSuite2pClassificationModule:
         stat = np.load(get_test_dir_path.joinpath('classification', 'pre_stat.npy'), allow_pickle=True)
         iscell = classification.Classifier(default_cls_file, keys=['npix_norm', 'compact', 'skew']).run(stat)
         expected_output = np.load(get_test_dir_path.joinpath('1plane1chan', 'suite2p', 'plane0', 'iscell.npy'))
-        assert np.array_equal(iscell, expected_output)
+        # Logistic Regression has differences in tolerance due to depndence on C
+        assert np.allclose(iscell, expected_output, atol=1e-4)

--- a/tests/test_modules/test_detection_and_extraction_module.py
+++ b/tests/test_modules/test_detection_and_extraction_module.py
@@ -1,22 +1,37 @@
 import numpy as np
 from pathlib import Path
-from suite2p import extraction
+from suite2p import extraction, registration
 
 
-def prepare_for_detection(op, input_file_name, dimensions):
+def prepare_for_detection(op, input_file_name_list, dimensions, test_utils):
     """
     Prepares for detection by filling out necessary ops parameters. Removes dependence on
     other modules. Creates pre_registered binary file.
     """
-    op['Lx'] = dimensions[0]
-    op['Ly'] = dimensions[1]
-    input_data = np.fromfile(str(input_file_name), np.int16)
-    bin_file_path = str(Path(op['save_path0']).joinpath('data.bin'))
-    with open(bin_file_path, 'wb') as f:
-        f.write(input_data)
-    op['reg_file'] = bin_file_path
-    op['save_path'] = op['save_path0']
-    return op
+    # Set appropriate ops parameters
+    op['Lx'], op['Ly'] = dimensions
+    op['nframes'] = 500 // op['nplanes'] // op['nchannels']
+    op['frames_per_file'] = 500 // op['nplanes'] // op['nchannels']
+    op['xrange'], op['yrange'] = [[2, 402], [2, 358]]
+    ops = []
+    for plane in range(op['nplanes']):
+        curr_op = op.copy()
+        plane_dir = test_utils.create_plane_dir(op, plane)
+        bin_path = test_utils.write_data_to_binary(
+            str(plane_dir.joinpath('data.bin')), str(input_file_name_list[plane][0])
+        )
+        curr_op['reg_file'] = bin_path
+        if plane == 1: # Second plane result has different crop.
+            curr_op['xrange'], curr_op['yrange'] = [[1, 403], [1, 359]]
+        if curr_op['nchannels'] == 2:
+            bin2_path = test_utils.write_data_to_binary(
+                str(plane_dir.joinpath('data_chan2.bin')), str(input_file_name_list[plane][1])
+            )
+            curr_op['reg_file_chan2'] = bin2_path
+        curr_op['save_path'] = plane_dir
+        curr_op['ops_path'] = plane_dir.joinpath('ops.npy')
+        ops.append(curr_op)
+    return ops
 
 
 class TestSuite2pDetectionExtractionModule:
@@ -25,8 +40,39 @@ class TestSuite2pDetectionExtractionModule:
     """
     # TODO: Separate once the detection module is created.
 
-    def test_detection_extraction_output_1plane1chan(self, setup_and_teardown, get_test_dir_path):
+    def test_detection_extraction_output_1plane1chan(self, setup_and_teardown, get_test_dir_path, test_utils):
         op, tmp_dir = setup_and_teardown
-        op = prepare_for_detection(
-            op, op['data_path'][0].joinpath('detection', 'pre_registered.npy'), (404, 360)
+        ops = prepare_for_detection(
+            op, [[op['data_path'][0].joinpath('detection', 'pre_registered.npy')]], (404, 360),
+            test_utils
+        )
+        # Detection Part
+        for op in ops:
+            op = extraction.detect_and_extract(op)
+        test_utils.check_output(
+            tmp_dir, ['F', 'Fneu', 'iscell', 'stat'], get_test_dir_path, op['nplanes'], op['nchannels']
+        )
+
+    def test_detection_extraction_output_2plane2chan(self, setup_and_teardown, get_test_dir_path, test_utils):
+        op, tmp_dir = setup_and_teardown
+        op['nchannels'] = 2
+        op['nplanes'] = 2
+        detection_dir = op['data_path'][0].joinpath('detection')
+        ops = prepare_for_detection(
+            op,
+            [
+                [detection_dir.joinpath('pre_registered01.npy'), detection_dir.joinpath('pre_registered02.npy')],
+                [detection_dir.joinpath('pre_registered11.npy'), detection_dir.joinpath('pre_registered12.npy')]
+            ]
+            , (404, 360),
+            test_utils
+        )
+        ops[0]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p0.npy'))
+        ops[1]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p1.npy'))
+        # Detection Part
+        for op in ops:
+            op = extraction.detect_and_extract(op)
+        test_utils.check_output(
+            tmp_dir, ['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'iscell', 'stat'],
+            get_test_dir_path, op['nplanes'], op['nchannels']
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,13 @@ from pathlib import Path
 import suite2p
 
 
+def get_outputs_to_check(n_channels):
+    outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat']
+    if n_channels == 2:
+        outputs_to_check.extend(['F_chan2', 'Fneu_chan2'])
+    return outputs_to_check
+
+
 class TestCommonPipelineUseCases:
     """
     Class that tests common use cases for pipeline.
@@ -16,7 +23,9 @@ class TestCommonPipelineUseCases:
         ops, tmp_dir = setup_and_teardown
         suite2p.run_s2p(ops=ops)
         # Check outputs against ground_truth files
-        test_utils.check_output(tmp_dir, get_test_dir_path, ops['nplanes'], ops['nchannels'])
+        test_utils.check_output(
+            tmp_dir, get_outputs_to_check(ops['nchannels']), get_test_dir_path, ops['nplanes'], ops['nchannels']
+        )
 
     def test_2plane_1chan(self, setup_and_teardown, get_test_dir_path, test_utils):
         """
@@ -25,7 +34,9 @@ class TestCommonPipelineUseCases:
         ops, tmp_dir = setup_and_teardown
         ops['nplanes'] = 2
         suite2p.run_s2p(ops=ops)
-        test_utils.check_output(tmp_dir, get_test_dir_path, ops['nplanes'], ops['nchannels'])
+        test_utils.check_output(
+            tmp_dir, get_outputs_to_check(ops['nchannels']), get_test_dir_path, ops['nplanes'], ops['nchannels']
+        )
 
     def test_2plane_2chan(self, setup_and_teardown, get_test_dir_path, test_utils):
         """
@@ -35,4 +46,6 @@ class TestCommonPipelineUseCases:
         ops['nplanes'] = 2
         ops['nchannels'] = 2
         suite2p.run_s2p(ops=ops)
-        test_utils.check_output(tmp_dir, get_test_dir_path, ops['nplanes'], ops['nchannels'])
+        test_utils.check_output(
+            tmp_dir, get_outputs_to_check(ops['nchannels']), get_test_dir_path, ops['nplanes'], ops['nchannels']
+        )


### PR DESCRIPTION
Completed Detection/Extraction & Classification regression tests mentioned in #374 #373. 

**Detection/Extraction**
- The 1chan and 2chan tests for detection/extraction have been added. 2chan tests for this module was added since `detect_and_extract` has a substantial portion of code for channel 2 (`chan2detect`).
- Added registered inputs for both tests above

**Classification**
- Tests for `classification.classifier` added.
-  Added stats input for use with classifier