### PR TITLE
Added 2 channel smoothed test for registration module.

### DIFF
--- a/data/test_data/registration/regression_1preg_output.tif.dvc
+++ b/data/test_data/registration/regression_1preg_output.tif.dvc
@@ -1,7 +1,0 @@
-md5: efa575106befb817dcd1bd168181bcf1
-outs:
-- md5: d918e75dfc435d2f175a4d2dcc91a0d3
-  path: regression_1preg_output.tif
-  cache: true
-  metric: false
-  persist: false

--- a/data/test_data/registration/regression_smoothed_chan0.tif.dvc
+++ b/data/test_data/registration/regression_smoothed_chan0.tif.dvc
@@ -1,0 +1,7 @@
+md5: 9d7feb8a08a89566c6b88ac0d1a9c97a
+outs:
+- md5: 9aeb3b0d8d83ea1022d813310939338c
+  path: regression_smoothed_chan0.tif
+  cache: true
+  metric: false
+  persist: false

--- a/data/test_data/registration/regression_smoothed_chan1.tif.dvc
+++ b/data/test_data/registration/regression_smoothed_chan1.tif.dvc
@@ -1,0 +1,7 @@
+md5: f81083ec33b42413ee05efe31e633780
+outs:
+- md5: b7fa505249e816c7592c85a08a7758fc
+  path: regression_smoothed_chan1.tif
+  cache: true
+  metric: false
+  persist: false

--- a/tests/test_modules/test_registration_module.py
+++ b/tests/test_modules/test_registration_module.py
@@ -16,28 +16,51 @@ def prepare_for_registration(op, input_file_name, dimensions):
     op['reg_tif'] = True
     op['Lx'] = dimensions[0]
     op['Ly'] = dimensions[1]
+    nc = op['nchannels']
     # Make input data non-negative
     input_data = (imread(
         str(input_file_name)
     ) // 2).astype(np.int16)
-    bin_file_path = str(Path(op['save_path0']).joinpath('data.bin'))
-    # Generate binary file
-    with open(bin_file_path, 'wb') as f:
-        f.write(input_data)
-    op['reg_file'] = bin_file_path
-    op['save_path'] = op['save_path0']
-    return op
+    nframes_per_plane = input_data.shape[0] // op['nplanes']
+    ops = []
+    for i in range(op['nplanes']):
+        # split image by number of planes
+        plane_start = i * nframes_per_plane
+        chan1_end = plane_start + nframes_per_plane//nc if nc == 2 else nframes_per_plane*(i+1)
+        curr_op = op.copy()
+        bin_file_path = str(Path(curr_op['save_path0']).joinpath('data_{}.bin'.format(i)))
+        # Generate binary file for chan1
+        with open(bin_file_path, 'wb') as f:
+            f.write(input_data[plane_start:chan1_end, :, :])
+        # Generate binary file for chan2
+        if nc == 2:
+            bin_file_path2 = str(Path(curr_op['save_path0']).joinpath('data_{}_2.bin'.format(i)))
+            with open(bin_file_path2, 'wb') as f2:
+                f2.write(input_data[chan1_end:nframes_per_plane*(i+1), :, :])
+            curr_op['reg_file_chan2'] = bin_file_path2
+        curr_op['reg_file'] = bin_file_path
+        curr_op['save_path'] = op['save_path0']
+        ops.append(curr_op)
+    return ops
 
 
-def check_registration_output(op, dimensions, input_path, reg_output_path, output_path):
-    op = prepare_for_registration(
+def check_registration_output(op, dimensions, input_path, reg_output_path_list, output_path_list):
+    ops = prepare_for_registration(
         op, input_path, dimensions
     )
-    op = registration.register_binary(op)
-    registered_data = imread(reg_output_path)
-    output_check = imread(output_path)
-    assert np.array_equal(registered_data, output_check)
-    return op
+    reg_ops = []
+    npl = op['nplanes']
+    for i in range(npl):
+        curr_op = registration.register_binary(ops[i])
+        registered_data = imread(reg_output_path_list[i*npl])
+        output_check = imread(output_path_list[i*npl])
+        assert np.array_equal(registered_data, output_check)
+        if op['nchannels'] == 2:
+            registered_data = imread(reg_output_path_list[i * npl + 1])
+            output_check = imread(output_path_list[i * npl + 1])
+            assert np.array_equal(registered_data, output_check)
+        reg_ops.append(curr_op)
+    return reg_ops
 
 
 def test_register_binary_output_with_metrics(default_ops):
@@ -49,10 +72,10 @@ def test_register_binary_output_with_metrics(default_ops):
     op = check_registration_output(
         default_ops, (256, 256),
         default_ops['data_path'][0].joinpath('registration', 'input_1500.tif'),
-        str(Path(default_ops['save_path0']).joinpath('reg_tif', 'file000_chan0.tif')),
-        str(Path(default_ops['data_path'][0]).joinpath('registration', 'regression_output.tif'))
+        [str(Path(default_ops['save_path0']).joinpath('reg_tif', 'file000_chan0.tif'))],
+        [str(Path(default_ops['data_path'][0]).joinpath('registration', 'regression_output.tif'))]
     )
-    registration.get_pc_metrics(op)
+    registration.get_pc_metrics(op[0])
 
 
 def test_register_binary_do_bidi_output(default_ops):
@@ -63,22 +86,10 @@ def test_register_binary_do_bidi_output(default_ops):
     check_registration_output(
         default_ops, (404, 360),
         default_ops['data_path'][0].joinpath('registration', 'bidi_shift_input.tif'),
-        str(Path(default_ops['save_path0']).joinpath('reg_tif', 'file000_chan0.tif')),
-        str(Path(default_ops['data_path'][0]).joinpath('registration', 'regression_bidi_output.tif'))
+        [str(Path(default_ops['save_path0']).joinpath('reg_tif', 'file000_chan0.tif'))],
+        [str(Path(default_ops['data_path'][0]).joinpath('registration', 'regression_bidi_output.tif'))]
     )
 
-def test_register_binary_1preg_output(default_ops):
-    """
-    Regression test that checks the output of register_binary with 1Preg given the `input.tif`.
-    """
-    default_ops['1Preg'] = True
-    default_ops['smooth_sigma_time'] = 1
-    check_registration_output(
-        default_ops, (404, 360),
-        default_ops['data_path'][0].joinpath('input.tif'),
-        str(Path(default_ops['save_path0']).joinpath('reg_tif', 'file000_chan0.tif')),
-        str(Path(default_ops['data_path'][0]).joinpath('registration', 'regression_1preg_output.tif'))
-    )
 
 def test_register_binary_rigid_registration_only(default_ops):
     """
@@ -87,7 +98,7 @@ def test_register_binary_rigid_registration_only(default_ops):
     default_ops['nonrigid'] = False
     op = prepare_for_registration(
         default_ops, default_ops['data_path'][0].joinpath('registration', 'rigid_registration_test_data.tif'), (256,256)
-    )
+    )[0]
     op = registration.register_binary(op)
     registered_data = imread(str(Path(op['save_path']).joinpath('reg_tif', 'file000_chan0.tif')))
     # Make sure registered_data is identical across frames
@@ -99,3 +110,24 @@ def test_register_binary_rigid_registration_only(default_ops):
     assert num_col_lines == 16
     assert num_row_lines == 16
 
+
+def test_register_binary_smoothed_output(default_ops):
+    """
+    Regression test that checks the output of register_binary with smooth_sigma_time=1 and 2planes/2channels
+    given the `input.tif`.
+    """
+    default_ops['smooth_sigma_time'] = 1
+    default_ops['nchannels'] = 2
+    default_ops['reg_tif_chan2'] = True
+    check_registration_output(
+        default_ops, (404, 360),
+        default_ops['data_path'][0].joinpath('input.tif'),
+        [
+            str(Path(default_ops['save_path0']).joinpath('reg_tif', 'file000_chan0.tif')),
+            str(Path(default_ops['save_path0']).joinpath('reg_tif_chan2', 'file000_chan1.tif'))
+        ],
+        [
+            str(Path(default_ops['data_path'][0]).joinpath('registration', 'regression_smoothed_chan0.tif')),
+            str(Path(default_ops['data_path'][0]).joinpath('registration', 'regression_smoothed_chan1.tif'))
+        ]
+    )


### PR DESCRIPTION
PR addresses issue #371. 

- 1Preg test was removed.
- regression test for 2channels with `smooth_sigma_time` = 1 was added. 
- Refactoring of `prepare_for_registration` function to accommodate multiple channels and planes.
- Added 2channels smoothed test data. 