### PR TITLE
Separated classification from extraction

### DIFF
--- a/suite2p/classification/__init__.py
+++ b/suite2p/classification/__init__.py
@@ -1,1 +1,2 @@
 from .classifier import Classifier
+from .classify import classify

--- a/suite2p/classification/classify.py
+++ b/suite2p/classification/classify.py
@@ -1,0 +1,50 @@
+import os
+import numpy as np
+from pathlib import Path
+from . import Classifier
+
+
+def classify(ops, stat):
+    """
+    Applies classifier and saves output to iscell.npy. Also, saves stat.npy.
+
+    Parameters
+    ----------
+    ops : dictionary
+        'save_path'
+        (optional 'preclassify')
+
+    stat : array of dicts
+
+    Returns
+    -------
+
+    ops : dictionary
+
+    stat : array of dicts
+
+    iscell : array of classifier output
+
+    """
+    # apply default classifier
+    if len(stat) > 0:
+        user_dir = Path.home().joinpath('.suite2p')
+        classfile = user_dir.joinpath('classifiers', 'classifier_user.npy')
+        if not Path(classfile).is_file():
+            s2p_dir = Path(__file__).parent.parent
+            classfile = os.fspath(s2p_dir.joinpath('classifiers', 'classifier.npy'))
+        print('NOTE: applying classifier %s'%classfile)
+        iscell = Classifier(classfile, keys=['npix_norm', 'compact', 'skew']).run(stat)
+        # Code Below does not work. Setting ops['preclassify'] gives you typeError.
+        # if 'preclassify' in ops and ops['preclassify'] > 0.0:
+        #     ic = (iscell[:,0]>ops['preclassify']).flatten().astype(np.bool)
+        #     stat = stat[ic]
+        #     iscell = iscell[ic]
+        #     print('After classification with threshold %0.2f, %d ROIs remain'%(ops['preclassify'], len(stat)))
+        #     np.save(fpath.joinpath(('stat.npy')), stat)
+        # else:
+    else:
+        iscell = np.zeros((0,2))
+    fpath = Path(ops['save_path'])
+    np.save(fpath.joinpath(('iscell.npy')), iscell)
+    return ops, iscell, stat

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -6,7 +6,7 @@ import time
 import numpy as np
 from scipy.io import savemat
 
-from . import extraction, io, registration, detection
+from . import extraction, io, registration, detection, classification
 
 try:
     from haussmeister import haussio
@@ -291,9 +291,16 @@ def run_s2p(ops={},db={}):
             ######## ROI EXTRACTION ##############
             t11=time.time()
             print('----------- EXTRACTION')
-            ops1[ipl] = extraction.extract(ops1[ipl], cell_pix, cell_masks, neuropil_masks, stat)
+            ops1[ipl], stat = extraction.extract(ops1[ipl], cell_pix, cell_masks, neuropil_masks, stat)
             ops = ops1[ipl]
             fpath = ops['save_path']
+            print('----------- Total %0.2f sec.'%(time.time()-t11))
+
+            ######## ROI CLASSIFICATION ##############
+            t11=time.time()
+            print('----------- CLASSIFICATION')
+            ops1[ipl], stat, iscell = classification.classify(ops1[ipl], stat)
+            ops = ops1[ipl]
             print('----------- Total %0.2f sec.'%(time.time()-t11))
 
             ######### SPIKE DECONVOLUTION ###############

--- a/tests/test_modules/test_classification_module.py
+++ b/tests/test_modules/test_classification_module.py
@@ -6,13 +6,29 @@ import numpy as np
 from suite2p import classification
 
 
-def test_classification_output(data_dir):
+def get_stat_iscell(data_dir_path):
+    # stat with standard deviation and skew already calculated
+    stat = np.load(data_dir_path.joinpath('classification', 'pre_stat.npy'), allow_pickle=True)
+    expected_output = np.load(data_dir_path.joinpath('1plane1chan', 'suite2p', 'plane0', 'iscell.npy'))
+    return stat, expected_output
+
+
+def test_classification_output(default_ops, data_dir):
     """
-    Regression test that checks the output of classification.
+    Regression test that checks to see if the main_classify function works. Only checks iscell output.
+    """
+    default_ops['save_path'] = default_ops['save_path0']
+    stat, expected_output = get_stat_iscell(data_dir)
+    ops, iscell, stat = classification.classify(default_ops, stat)
+    assert np.allclose(iscell, expected_output, atol=2e-4)
+
+
+def test_classifier_output(data_dir):
+    """
+    Regression test that checks to see if classifier works.
     """
     default_cls_file = data_dir.parent.parent.joinpath('suite2p', 'classifiers', 'classifier.npy')
-    stat = np.load(data_dir.joinpath('classification', 'pre_stat.npy'), allow_pickle=True)
+    stat, expected_output = get_stat_iscell(data_dir)
     iscell = classification.Classifier(default_cls_file, keys=['npix_norm', 'compact', 'skew']).run(stat)
-    expected_output = np.load(data_dir.joinpath('1plane1chan', 'suite2p', 'plane0', 'iscell.npy'))
     # Logistic Regression has differences in tolerance due to dependence on C
     assert np.allclose(iscell, expected_output, atol=2e-4)

--- a/tests/test_modules/test_extraction_module.py
+++ b/tests/test_modules/test_extraction_module.py
@@ -74,7 +74,7 @@ def test_extraction_output_1plane1chan(default_ops):
     extract_wrapper(ops)
     utils.check_output(
         default_ops['save_path0'],
-        ['F', 'Fneu', 'iscell', 'stat', 'spks'],
+        ['F', 'Fneu', 'stat', 'spks'],
         default_ops['data_path'][0],
         default_ops['nplanes'],
         default_ops['nchannels'],
@@ -98,7 +98,7 @@ def test_extraction_output_2plane2chan(default_ops):
     extract_wrapper(ops)
     utils.check_output(
         default_ops['save_path0'],
-        ['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'iscell', 'stat', 'spks'],
+        ['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks'],
         default_ops['data_path'][0],
         default_ops['nplanes'],
         default_ops['nchannels'],


### PR DESCRIPTION
PR (addresses #397) contains the following: 

- Separated classification from extraction. Created `classify.py` under `classification` subpackage that applies default/user-specified classifier. 
- Added call to `classify.classify` in `run_s2p.py`. 
- Added regression test to check output of `classify.classify`.
- Removed check for `iscell.npy` from extraction tests. This now is checked in the added classification test.

Picture below: classification doesn't point to extraction anymore. 
![classification_changed](https://user-images.githubusercontent.com/10649054/84716118-28b8b380-af27-11ea-8de5-421797c5b869.png)
