### PR TITLE
added type annotation support for docs

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -47,3 +47,4 @@
 /tmp
 /tmp
 /tmp
+/tmp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,8 +38,11 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.coverage',
     'sphinx-prompt',
-    'sphinxcontrib.apidoc']
- #   'sphinx.ext.autosummary']
+    'sphinxcontrib.apidoc',
+    'sphinx_autodoc_typehints',
+#   'sphinx.ext.autosummary',
+]
+
 
 #autodoc_default_flags = ['members']
 #autosummary_generate = True

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setuptools.setup(
         'sphinx>=3.0',
         'sphinxcontrib-apidoc',
         'sphinx_rtd_theme',
-        'sphinx-prompt'
+        'sphinx-prompt',
+        'sphinx-autodoc-typehints',
       ],
       # Note: Available in pypi, but cleaner to install as pyqt from conda.
       "gui": [


### PR DESCRIPTION
Hi,

Suite2p has been getting a lot of type annotations, which make it easier to maintain and decrease the length of the docstrings (sometimes by a lot!), but those annotations haven't been showing up in the sphinx-generated online documentation.  That means that only by looking at the source code can you understand how the functions work.  This commit uses the sphinx-autodoc-typehints package to add type annotations to the docs, so everyone can see!

Best wishes,

Nick