### PR TITLE
Include MacOS in travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: python
-os:
-- linux
-- osx
-python:
-- '3.7'
+jobs:
+  include:
+    - name: "Python 3.7.0 on Linux"
+      python: 3.7
+    - name: "Python 3.7.4 on macOS"
+      os: osx
+      osx_image: xcode12
+      language: shell       # 'language: python' is an error on Travis CI macOS
+  allow_failures:
+    - os: osx
+
 before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - bash ./miniconda.sh -b
@@ -27,6 +33,3 @@ deploy:
     secure: KMUsze0SI8xGbgK1pzSRQGFcal8YPLF0eMk1zNGhDA/e5qwk8AToQsbokdyTa7sz/2RAjvsIQUsM2+XIMKXQo/9zCp9Sb5RP9Aqh8E9F9uj5a+UGgC6KDZa+zPFFARDNjcasS/RTm0K77gFAWhfwk0smiuR6mSQjXWYwjAZ8CejOc1CWm11MzaVPcp1AJM8r/h3Q2ulFcwHGgteZEXxgtZh3CQoGgxxAQFLIae3G0TzxoK3Amr7e6WTKDvY16YOEzUWQ+77aB6llOHqNU8edq/qKORnwhjcKsIiwqIsiGAfkYm/zT4n40/+P43dfFGfNj3jB3Yqr0HMhFVs4H9yADaommsBX4nAbSA7lKdxf0ds9wUZLRbwSnkx9RhEG05aALyMXNUZVbd+gUPhK/94o7kWOlaOSzOWQaVZ/2pmNjQbjcQ/cNkt5WM+9PNrmrP2E1VstnalODfyOcvM7G6afU3oKUD1/q5vT19C/EzIayR12w7aVImkGlt8qKI6Fxsg+MVSMrPX/7uxEpQXltX00a15b+5XA9zmyBurdbsAgD6zTPOlkysXaXhOMd4L+XE4Z0iDRQmx6WK2whELL1Qa03F6hI+Y9FVZze86FfewmGDgF+IaU3b5d1C6OdsGBZbHOW3ZEEAmuj6abe7LRF2oDLEi9bCqXiVl0RAR7PFIFEHQ=
   on:
     tags: true
-jobs:
-  allow_failures:
-    - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,25 @@
 language: python
 jobs:
   include:
-    - name: "Python 3.7.0 on Linux"
+    - name: "Python 3.7.1 on Linux"
       python: 3.7
+      before_install:
+        - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+        - bash ./miniconda.sh -b
+        - export PATH=~/miniconda3/bin:$PATH
+        - conda update --yes conda
     - name: "Python 3.7.4 on macOS"
       os: osx
       osx_image: xcode12
-      language: shell       # 'language: python' is an error on Travis CI macOS
+      language: shell
+      before_install:
+        - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
+        - bash ./miniconda.sh -b
+        - export PATH=~/miniconda3/bin:$PATH
+        - conda update --yes conda
   allow_failures:
     - os: osx
 
-before_install:
-- wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-- bash ./miniconda.sh -b
-- export PATH=~/miniconda3/bin:$PATH
-- conda update --yes conda
 install:
 - conda env create -f environment.yml
 - source activate suite2p

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
         - bash ./miniconda.sh -b
         - export PATH=~/miniconda3/bin:$PATH
         - conda update --yes conda
-    - name: "Python 3.7.4 on macOS"
+    - name: "Python 3.7.7 on macOS"
       os: osx
       osx_image: xcode12
       language: shell

--- a/docs/developer_doc.rst
+++ b/docs/developer_doc.rst
@@ -11,6 +11,12 @@ Suite2p depends on `dvc`_ to download the test data. Before testing, make sure y
 .. prompt:: bash
 
     pip install dvc
+The command above may prompt you to install `pydrive2`. Install it and you should be good to go.
+
+.. prompt:: bash
+
+    pip install pydrive2
+
 
 Use to following command to download the test data into the ``data`` subdirectory of your working ``suite2p`` directory.
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setuptools.setup(
       'natsort',
       'rastermap>0.1.0',
       'tifffile',
-      'tqdm',
       'scanimage-tiff-reader',
       'pyqtgraph',
     ],

--- a/suite2p/registration/register.py
+++ b/suite2p/registration/register.py
@@ -5,7 +5,6 @@ from warnings import warn
 
 import numpy as np
 from scipy.signal import medfilt
-from tqdm import tqdm
 
 from suite2p import io
 from suite2p.registration import bidiphase, utils, rigid, nonrigid


### PR DESCRIPTION
PR addresses #438 and #440:  

- Travis now builds for macOS and runs tests. The macOS build is much slower than the Linux build but builds are made in parallel. Travis responses should take a few minutes more than usual. 
- Verifies that `suite2p` works fine on macOS with version 1.4.1 of `scanimage-tiff-reader` 