### PR TITLE
minor import fixes (absolute -> relative, package -> module)

### DIFF
--- a/suite2p/classification/classify.py
+++ b/suite2p/classification/classify.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 from pathlib import Path
-from . import Classifier
+from .classifier import Classifier
 
 
 def classify(ops, stat, classfile=None, keys=['npix_norm', 'compact', 'skew']):

--- a/suite2p/io/h5.py
+++ b/suite2p/io/h5.py
@@ -4,7 +4,7 @@ import h5py
 import numpy as np
 import os
 
-from . import utils
+from .utils import init_ops, find_files_open_binaries
 
 
 def h5py_to_binary(ops):
@@ -22,13 +22,13 @@ def h5py_to_binary(ops):
             'Ly', 'Lx', ops1[j]['reg_file'] or ops1[j]['raw_file'] is created binary
 
     """
-    ops1 = utils.init_ops(ops)
+    ops1 = init_ops(ops)
 
     nplanes = ops1[0]['nplanes']
     nchannels = ops1[0]['nchannels']
 
     # open all binary files for writing
-    ops1, h5list, reg_file, reg_file_chan2 = utils.find_files_open_binaries(ops1, True)
+    ops1, h5list, reg_file, reg_file_chan2 = find_files_open_binaries(ops1, True)
     for ops in ops1:
         if 'data_path' in ops and len(ops['data_path'])==0:
             ops['data_path'] = [os.path.dirname(ops['h5py'])]

--- a/suite2p/io/sbx.py
+++ b/suite2p/io/sbx.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 
-from . import utils
+from .utils import init_ops, find_files_open_binaries
 
 
 def sbx_get_info(sbxfile):
@@ -95,12 +95,12 @@ def sbx_to_binary(ops,ndeadcols = -1):
 
     """
 
-    ops1 = utils.init_ops(ops)
+    ops1 = init_ops(ops)
     # the following should be taken from the metadata and not needed but the files are initialized before...
     nplanes = ops1[0]['nplanes']
     nchannels = ops1[0]['nchannels']
     # open all binary files for writing
-    ops1, sbxlist, reg_file, reg_file_chan2 = utils.find_files_open_binaries(ops1)
+    ops1, sbxlist, reg_file, reg_file_chan2 = find_files_open_binaries(ops1)
     iall = 0
     for j in range(ops1[0]['nplanes']):
         ops1[j]['nframes_per_folder'] = np.zeros(len(sbxlist), np.int32)

--- a/suite2p/registration/register.py
+++ b/suite2p/registration/register.py
@@ -6,8 +6,8 @@ from warnings import warn
 import numpy as np
 from scipy.signal import medfilt
 
-from suite2p import io
-from suite2p.registration import bidiphase, utils, rigid, nonrigid
+from .. import io
+from . import bidiphase, utils, rigid, nonrigid
 
 
 def compute_crop(xoff, yoff, corrXY, th_badframes, badframes, maxregshift, Ly, Lx):


### PR DESCRIPTION
closes #349 , leaving circular imports in the following exceptions:

  - io.nwb
  - gui.merge <-> gui.masks