### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install an [Anaconda](https://www.anaconda.com/download/) distribution of Python
 3. Change directories to where the `environment.yml` is and run `conda env create -f environment.yml`
 4. Activate the environment with `conda activate suite2p'
 5. Pip install suite2p into the environment: `pip install suite2p`
-6. Now run `python -m suite2p` and you're all set.
+6. Now run `suite2p` and you're all set.
 
 If you have an older `suite2p` environment you can remove it with `conda env remove -n suite2p` before creating a new one.
 
@@ -70,7 +70,7 @@ An example dataset is provided [here](https://drive.google.com/open?id=1PCJy265N
 
 The quickest way to start is to open the GUI from a command line terminal. You might need to open an anaconda prompt if you did not add anaconda to the path. Make sure to run this from a directory in which you have **WRITE** access (suite2p saves a couple temporary files in your current directory):
 ~~~~
-python -m suite2p
+suite2p
 ~~~~
 Then:
 1. File -> Run suite2p (or ctrl+r)
@@ -117,7 +117,7 @@ You can add your manual curation to a pre-built classifier by clicking "Add curr
 
 1. From the command line:
 ~~~~
-python -m suite2p --ops <path to ops.npy> --db <path to db.npy>
+suite2p --ops <path to ops.npy> --db <path to db.npy>
 ~~~~
 
 2. From Python/Jupyter

--- a/benchmarks/registration_metrics.py
+++ b/benchmarks/registration_metrics.py
@@ -21,7 +21,8 @@ def registration_metrics(data_path, tiff_list, ops, nPC=10):
     ops['roidetect'] = False
     ops['reg_metric_n_pc'] = nPC
     ops['data_path'] = data_path
-    ops['tiff_list'] = tiff_list
+    if tiff_list:
+        ops['tiff_list'] = tiff_list
 
     result_ops = suite2p.run_s2p(ops)
     metric_results = []

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ if you did not add anaconda to the path.
 4. Run ``conda env create -f environment.yml``
 5. To activate this new environment, run ``conda activate suite2p``. Afterwards, You should see ``(suite2p)`` on the left side of the terminal line.
 6. Install suite2p into this environment: ``pip install suite2p``
-7. Now run ``python -m suite2p`` and you're all set.
+7. Now run ``suite2p`` and you're all set.
 
 If you have an older ``suite2p`` environment you can remove it with
 ``conda env remove -n suite2p`` before creating a new one.
@@ -31,7 +31,7 @@ environment:
 
 **Common issues**
 
-If when running ``python -m suite2p``, you receive the error:
+If when running ``suite2p``, you receive the error:
 ``No module named PyQt5.sip``, then try uninstalling and reinstalling
 pyqt5
 
@@ -40,7 +40,7 @@ pyqt5
    pip uninstall pyqt5 pyqt5-tools
    pip install suite2p
 
-If when running ``python -m suite2p``, you receive an error associated
+If when running ``suite2p``, you receive an error associated
 with **matplotlib**, try upgrading it:
 
 ::

--- a/suite2p/__main__.py
+++ b/suite2p/__main__.py
@@ -33,19 +33,25 @@ def parse_args(parser: argparse.ArgumentParser):
     set_param_msg = '->> Setting {0} to {1}'
     # options defined in the cli take precedence over the ones in the ops file
     for k in ops0:
-        v = ops0[k]
-        n = dargs[k]
+        default_key = ops0[k]
+        args_key = dargs[k]
         if k in ['fast_disk', 'save_folder', 'save_path0']:
-            if n:
-                ops[k] = n
+            if args_key:
+                ops[k] = args_key
                 print(set_param_msg.format(k, ops[k]))
-        elif type(v) in [np.ndarray, list]:
-            n = np.array(n)
-            if np.any(n != np.array(v)):
-                ops[k] = n.astype(type(v))
+        elif type(default_key) in [np.ndarray, list]:
+            n = np.array(args_key)
+            if np.any(n != np.array(default_key)):
+                ops[k] = n.astype(type(default_key))
                 print(set_param_msg.format(k, ops[k]))
-        elif not v == type(v)(n):
-            ops[k] = type(v)(n)
+        elif isinstance(default_key, bool):
+            args_key = bool(int(args_key))  # bool('0') is true, must convert to int
+            if default_key != args_key:
+                ops[k] = args_key
+                print(set_param_msg.format(k, ops[k]))
+        # checks default param to args param by converting args to same type
+        elif not (default_key == type(default_key)(args_key)):
+            ops[k] = type(default_key)(args_key)
             print(set_param_msg.format(k, ops[k]))
     return args, ops
 


### PR DESCRIPTION
Small PR that contains the following: 

- changes in readme and docs that point users to use console script entry point `suite2p` (works great!) instead of `python -m suite2p`
- change variable names for main cli script to make args/default vars clearer
- Fixed bug with main CLI script not correctly setting boolean parameters that have defaults to `True`. For instance, if you pass `--nonrigid 0` nonrigid wouldn't ever be changed. 