### PR TITLE
Remove run_s2p dependency on ops1 for running

### DIFF
--- a/suite2p/__main__.py
+++ b/suite2p/__main__.py
@@ -58,10 +58,10 @@ def parse_args(parser: argparse.ArgumentParser):
 
 def main():
     args, ops = parse_args(add_args(argparse.ArgumentParser(description='Suite2p parameters')))
-    if args.single_plane:
+    if args.single_plane and args.ops:
         from suite2p.run_s2p import run_plane
         # run single plane (does registration)
-        run_plane(ops)
+        run_plane(ops, ops_path=args.ops)
     elif len(args.db) > 0:
         db = np.load(args.db, allow_pickle=True).item()
         from suite2p import run_s2p

--- a/suite2p/detection/detect.py
+++ b/suite2p/detection/detect.py
@@ -28,7 +28,7 @@ def detect(ops):
         y_range=ops['yrange'],
         x_range=ops['xrange'],
     )
-    ops['nbinned'] = mov.shape[0]
+    #ops['nbinned'] = mov.shape[0]
     print('Binned movie [%d,%d,%d], %0.2f sec.' % (mov.shape[0], mov.shape[1], mov.shape[2], time.time() - t0))
 
 

--- a/suite2p/detection/utils.py
+++ b/suite2p/detection/utils.py
@@ -21,7 +21,6 @@ def reject_frames(mov: np.ndarray, bad_indices: Sequence[int], mov_indices: Opti
     Uses the indices of 'mov' by default, but can use alternate indices in 'mov_indices' to match with bad_indices.
     """
     n_frames, Ly, Lx = mov.shape
-    print(mov.shape)
     indices = mov_indices if mov_indices is not None else np.arange(n_frames)
     if len(indices) != n_frames:
         raise TypeError("'mov_indices' must be the same length as the movie, in order to match them up properly.")
@@ -30,7 +29,6 @@ def reject_frames(mov: np.ndarray, bad_indices: Sequence[int], mov_indices: Opti
     # (indices are in reference frame of total movie not chunk)
     good_frames -= indices[0]
     good_mov = mov[good_frames] if len(good_frames) / len(indices) > reject_threshold else mov
-    print(good_mov.shape)
     return good_mov
 
 

--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -125,16 +125,16 @@ def bin_movie(filename: str, Ly: int, Lx: int, bin_size: int, n_frames: int, x_r
         batches = []
         batch_size = min(n_frames - len(bad_frames), 500) // bin_size * bin_size
         for indices, data in f.iter_frames(batch_size=batch_size):
-
             if len(x_range) and len(y_range):
                 data = crop(mov=data, y_range=y_range, x_range=x_range)
 
             if len(bad_frames) > 0:
                 data = reject_frames(mov=data, bad_indices=bad_frames, mov_indices=indices, reject_threshold=0.5)
-
-            dbin = binned_mean(mov=data, bin_size=bin_size)
-            if dbin.shape[0]>0:
-                batches.append(dbin)
+            
+            if data.shape[0] > bin_size:
+                dbin = binned_mean(mov=data, bin_size=bin_size)
+                if dbin.shape[0]>0:
+                    batches.append(dbin)
 
     mov = np.vstack(batches)
     return mov

--- a/suite2p/io/nwb.py
+++ b/suite2p/io/nwb.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from natsort import natsorted 
 
 import numpy as np
 import scipy
@@ -136,7 +137,12 @@ def read_nwb(fpath):
     return stat, ops, F, Fneu, spks, iscell, probcell, redcell, probredcell
 
 
-def save_nwb(ops1):
+def save_nwb(save_folder):
+    """ convert folder with plane folders to NWB format """
+
+    plane_folders = natsorted([ f.path for f in os.scandir(save_folder) if f.is_dir() and f.name[:5]=='plane'])
+    ops1 = [np.load(os.path.join(f, 'ops.npy'), allow_pickle=True).item() for f in plane_folders]
+
     if NWB and not ops1[0]['mesoscan']:
         if len(ops1)>1:
             multiplane = True
@@ -273,7 +279,7 @@ def save_nwb(ops1):
                 
             ophys_module.add(images)
 
-        with NWBHDF5IO(os.path.join(ops['save_path0'], 'suite2p', 'ophys.nwb'), 'w') as fio:
+        with NWBHDF5IO(os.path.join(save_folder, 'ophys.nwb'), 'w') as fio:
             fio.write(nwbfile)
     else:
         print('pip install pynwb OR don"t use mesoscope recording')

--- a/suite2p/io/tiff.py
+++ b/suite2p/io/tiff.py
@@ -169,10 +169,8 @@ def tiff_to_binary(ops):
     do_registration = ops['do_registration']
     for ops in ops1:
         ops['Ly'],ops['Lx'] = ops['meanImg'].shape
-
-        if not do_registration:
-            ops['yrange'] = np.array([0,ops['Ly']])
-            ops['xrange'] = np.array([0,ops['Lx']])
+        ops['yrange'] = np.array([0,ops['Ly']])
+        ops['xrange'] = np.array([0,ops['Lx']])
         ops['meanImg'] /= ops['nframes']
         if nchannels>1:
             ops['meanImg_chan2'] /= ops['nframes']

--- a/suite2p/registration/register.py
+++ b/suite2p/registration/register.py
@@ -384,7 +384,7 @@ def register_binary(ops: Dict[str, Any], refImg=None, raw=True):
         Ly=ops['Ly'],
         Lx=ops['Lx'],
     )
-
+    
     if not raw:
         ops['bidi_corrected'] = True
 

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -143,7 +143,7 @@ def run_plane(ops, ops_path=None):
             if 'raw_file' in ops:
                 ops['raw_file'] = os.path.join(ops['save_path'], 'data_raw.bin')
             if 'raw_file_chan2' in ops:
-                ops['raw_file_chan2'] = os.path.join(ops['save_path'], 'data_raw_chan2.bin')
+                ops['raw_file_chan2'] = os.path.join(ops['save_path'], 'data_chan2_raw.bin')
 
     # check if registration should be done
     if ops['do_registration']>0:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -46,7 +46,6 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
         ]
     )
 
-
 def test_2plane_2chan_with_batches(test_ops):
     """
     Tests for case with 2 planes and 2 channels with multiple batches.
@@ -75,6 +74,7 @@ def test_1plane_2chan_sourcery(test_ops):
     test_ops['nchannels'] = 2
     test_ops['sparse_mode'] = 0
     test_ops['tiff_list'] = ['input.tif']
+    test_ops['keep_movie_raw'] = True
     suite2p.run_s2p(ops=test_ops)
     utils.check_output(
         test_ops['save_path0'],


### PR DESCRIPTION
refactored run_s2p so that `run_plane(ops)` is the standalone function for running on folders of `planeX` data

makes it easier to parallelize suite2p processing across planes on a computing cluster