### PR TITLE
Bugfix: Single version source

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Install an [Anaconda](https://www.anaconda.com/download/) distribution of Python
 4. Activate the environment with `conda activate suite2p'
 5. Pip install suite2p into the environment: `pip install suite2p`
 6. Now run `suite2p` and you're all set.
+7. Running the command `suite2p --version` in the terminal will print the install version of suite2p.
 
 If you have an older `suite2p` environment you can remove it with `conda env remove -n suite2p` before creating a new one.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="suite2p",
-    version="0.8.0",
     author="Marius Pachitariu and Carsen Stringer",
     author_email="marius10p@gmail.com",
     description="Pipeline for calcium imaging",
@@ -15,7 +14,9 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     setup_requires=[
       'pytest-runner',
+      'setuptools_scm',
     ],
+    use_scm_version=True,
     install_requires=[
       'numpy>=1.16',
       'numba>=0.43.1',

--- a/suite2p/__init__.py
+++ b/suite2p/__init__.py
@@ -1,4 +1,7 @@
+from importlib_metadata import metadata as _metadata
+
 from .run_s2p import run_s2p, default_ops
 from .gui import run as run_gui
 
 name = "suite2p"
+version = _metadata('suite2p')['version']

--- a/suite2p/__main__.py
+++ b/suite2p/__main__.py
@@ -1,6 +1,6 @@
 import argparse
 import numpy as np
-from suite2p import default_ops 
+from suite2p import default_ops, version
 
 def add_args(parser: argparse.ArgumentParser):
     """
@@ -9,6 +9,7 @@ def add_args(parser: argparse.ArgumentParser):
     parser.add_argument('--single_plane', action='store_true', help='run single plane ops')
     parser.add_argument('--ops', default=[], type=str, help='options')
     parser.add_argument('--db', default=[], type=str, help='options')
+    parser.add_argument('--version', action='store_true', help='print version number.')
     ops0 = default_ops()
     for k in ops0.keys():
         v = dict(default=ops0[k], help='{0} : {1}'.format(k, ops0[k]))
@@ -58,7 +59,9 @@ def parse_args(parser: argparse.ArgumentParser):
 
 def main():
     args, ops = parse_args(add_args(argparse.ArgumentParser(description='Suite2p parameters')))
-    if args.single_plane and args.ops:
+    if args.version:
+        print("suite2p v{}".format(version))
+    elif args.single_plane and args.ops:
         from suite2p.run_s2p import run_plane
         # run single plane (does registration)
         run_plane(ops, ops_path=args.ops)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+import suite2p
+from importlib_metadata import metadata
+
+
+def test_package_version_number_matches_setuptool_version_number():
+    assert suite2p.version == metadata('suite2p')['version']
+
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,14 @@
-import suite2p
+import os
 from importlib_metadata import metadata
+
+import suite2p
 
 
 def test_package_version_number_matches_setuptool_version_number():
     assert suite2p.version == metadata('suite2p')['version']
 
 
+def test_cli_provides_correct_package_number(capfd):
+    os.system('suite2p --version')
+    captured = capfd.readouterr()
+    assert metadata('suite2p')['version'] in captured.out


### PR DESCRIPTION
After #470, where the suite2p version number in setup.py stopped matching the git tag (and therefore, github release) number, I realized that we don't have clear ways to:

  -  ensure that the versions are always consistent between Pypi, the suite2p package, and Git
  -  ensure that users are providing correct version numbers (since there are multiple places they could be checking, especially if they aren't knowledgeable about where python installs things, or git branches)
  - have a simple way to check the version of the currently-installed suite2p.
  - ensure that the version number truly identifies the source code (i.e. if the version number is the same, then the code should be the same), to provide guarantees on reproducibility.

This pull request addresses that by anchoring everything to the latest git tag: the setuptools version, the PyPi release number, the GitHub release, the new `suite2p.version` variable, and the new CLI version function `suite2p --version` that prints the version number.  Updating the version is the same as before (just update the git tag), and the minor version number is calculated from commits after the tag, ensuring reproducibility and removing the need to manually check version number consistency.

The final benefit here is that it allows us to release new minor versions more often, so that users can easily download and upgrade their suite2p version from pypi and we as developers don't have commits on master that are intended to bypass the normal quality control and release processes.  If a single bugfix in dev is worth releasing to users, we can do it easily.

For more details on how this works behind the scenes:
   - Description of Travis, Git , Setuptools_scm workflow: https://medium.com/@Hironsan/automatically-releasing-your-python-package-to-pypi-using-travis-on-tagged-commits-64423e692440
  - Setuptools-scm readme (the tool that gets the version number from Git):  https://pypi.org/project/setuptools-scm/


To try it out in Python:
```python
import suite2p
print(suite2p.version)
```

From the terminal:
```
suite2p --version
```
