### PR TITLE
Added reg_metrics CLI script test and documented fix for versioning issue

### DIFF
--- a/docs/developer_doc.rst
+++ b/docs/developer_doc.rst
@@ -1,6 +1,16 @@
 Developer Documentation
 ---------------------------
 
+Versioning
+~~~~~~~~~~~~~~~~~~~~~
+There's a rare issue that developers may face when calling `suite2p --version` on their command line. You
+may get an incorrect version number. To fix this issue, one should use the following command:
+
+.. prompt:: bash
+
+        git fetch --prune --unshallow
+
+
 Testing
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -1,7 +1,7 @@
 import os
 
 
-def test_cli_help_test_appears_when_program_is_called(capfd):
+def test_cli_help_test_appears_when_suite2p_is_called(capfd):
     os.system('suite2p --help')
     captured = capfd.readouterr()
     assert 'Suite2p' in captured.out
@@ -9,9 +9,25 @@ def test_cli_help_test_appears_when_program_is_called(capfd):
     assert 'parameters' in captured.out
 
 
-def test_cli_help_test_appears_when_program_is_called2(capfd):
+def test_cli_help_test_appears_when_suite2p_is_called2(capfd):
     os.system('python -m suite2p --help')
     captured = capfd.readouterr()
     assert 'Suite2p' in captured.out
     assert 'usage' in captured.out
     assert 'parameters' in captured.out
+
+
+def test_cli_help_test_appears_when_reg_metrics_is_called(capfd):
+    os.system('reg_metrics --help')
+    captured = capfd.readouterr()
+    assert 'Suite2p' in captured.out
+    assert 'usage' in captured.out
+    assert 'parameters' in captured.out
+
+
+def test_cli_reg_metrics_runs_with_output(capfd, tmpdir):
+    os.system(
+        'reg_metrics data/test_data/ --tiff_list input_1500.tif --do_registration 2 --save_path0 {}'.format(tmpdir)
+    )
+    captured = capfd.readouterr()
+    assert captured.out


### PR DESCRIPTION
This PR addresses the following:

- Added a smoke test for `reg_metrics` cli command
- Adds versioning fix to documents for developers