### PR TITLE
added "neurepil_masks" ops key

### DIFF
--- a/jupyter/view_neuropil_masks.ipynb
+++ b/jupyter/view_neuropil_masks.ipynb
@@ -22,6 +22,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**IMPORTANT**: Before you run the cells below, make sure you've downloaded the test data. You can find instructions on how to download test data using dvc [here](https://suite2p.readthedocs.io/en/latest/developer_doc.html)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},

--- a/jupyter/view_neuropil_masks.ipynb
+++ b/jupyter/view_neuropil_masks.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from tempfile import TemporaryDirectory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import suite2p"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data_path': ['../data/test_data'],\n",
+       " 'save_path0': 'D:\\\\Temp\\\\tmp1p5ak5hx',\n",
+       " 'tiff_list': ['input_1500.tif']}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db = {\n",
+    "    'data_path': ['../data/test_data'],\n",
+    "    'save_path0': TemporaryDirectory().name,\n",
+    "    'tiff_list': ['input_1500.tif'],\n",
+    "}\n",
+    "db"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'data_path': ['../data/test_data'], 'save_path0': 'D:\\\\Temp\\\\tmp1p5ak5hx', 'tiff_list': ['input_1500.tif']}\n",
+      "tif\n",
+      "** Found 1 tifs - converting to binary **\n",
+      "time 1.45 sec. Wrote 1500 tiff frames to binaries for 1 planes\n",
+      ">>>>>>>>>>>>>>>>>>>>> PLANE 0 <<<<<<<<<<<<<<<<<<<<<<\n",
+      "NOTE: not registered / registration forced with ops['do_registration']>1\n",
+      "      (no previous offsets to delete)\n",
+      "----------- REGISTRATION\n",
+      "registering 1500 frames\n"
+     ]
+    }
+   ],
+   "source": [
+    "ops = suite2p.run_s2p(db=db)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(296, 65536)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "op = ops[0]\n",
+    "masks = op['neuropil_masks']\n",
+    "masks.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x1e43dd19948>"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQYAAAD8CAYAAACVSwr3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAARrUlEQVR4nO3df5TVdZ3H8edrBhgaVIL4EQIK6qhAKdJEmGW2lhLtBnbSQ1stnVxJxU4mecI6m9VZ9/QL7VRrSqnRrsGyoUfOmqZx2i0VgcFQ+REwIukAQWaKv/g1894/5otd+NyZucy9d+6dej3OmXPvfO7n+72v+ep5cb/fe7/fq4jAzCxXTaUDmFn1cTGYWcLFYGYJF4OZJVwMZpZwMZhZomzFIGmqpE2SmiXNK9fzmFnpqRyfY5BUC2wG3g+0AKuBj0bEhpI/mZmVXLleMUwGmiNia0TsBxYD08v0XGZWYn3KtN6RwLM5v7cA7+hocj/VRX8GlCmKmQG8xJ+fi4ihhcwtVzEoz9hh+yySZgOzAfpTzzt0fpmimBnAL+Nnvy90brl2JVqA0Tm/jwJ25E6IiAUR0RgRjX2pK1MMM+uOchXDaqBB0lhJ/YCZwLIyPZeZlVhZdiUi4qCkq4BfALXA7RGxvhzPZWalV65jDETEz4Gfl2v9ZlY+/uSjmSVcDGaWcDGYWcLFYGYJF4OZJVwMZpZwMZhZwsVgZgkXg5klXAxmlnAxmFnCxWBmCReDmSVcDGaWcDGYWcLFYGYJF4OZJVwMZpZwMZhZwsVgZgkXg5klXAxmlnAxmFnCxWBmCReDmSVcDGaWcDGYWcLFYGYJF4OZJVwMZpZwMZhZwsVgZgkXg5klXAxmluhTzMKStgEvAa3AwYholDQY+C9gDLANuCQi/lxcTDPrSaV4xfDeiJgYEY3Z7/OA5RHRACzPfjezXqQcuxLTgYXZ/YXAjDI8h5mVUbHFEMADktZImp2NDY+InQDZ7bB8C0qaLalJUtMB9hUZw8xKqahjDMA5EbFD0jDgQUm/K3TBiFgALAA4ToOjyBxmVkJFvWKIiB3Z7W7gbmAysEvSCIDsdnexIc2sZ3W7GCQNkHTsofvABcA6YBkwK5s2C7in2JBm1rOK2ZUYDtwt6dB6fhoR90taDSyRdCnwDHBx8THNrCd1uxgiYitwZp7xPwHnFxPKzCrLn3w0s4SLwcwSLgYzS7gYzCzhYjCzhIvBzBIuBjNLuBjMLOFiMLOEi8HMEi4GM0u4GMws4WIws4SLwcwSLgYzS7gYzCzhYjCzhIvBzBIuBjNLuBjMLOFiMLOEi8HMEi4GM0u4GKzHbbvhbPqcOJodd4/nj8tOY8fn31npSHaEYr/U1qwgetsEzr2jCYBbBn6LX1x0GpcNfJZa1fDEGXv55MufY+gtKyqc0g5RROW/aPo4DY53yF9e9deqz4mjufU3ixjV55gO5/y59VVeaGtjzrRLaV2/qQfT/e34ZfxsTUQ0FjLXuxJWVjVnjuOOhxZ3WgoAg2rrGdv3GO5+4D+JcyZSO/7UHkpo+bgYrGz2T307n116F8NqBxS8TJ368sB//5j3LllD27vPKmM664yLwcritRmT+ciN9zO1fl+3lr928FOc8Z3HaXuPy6ESXAxWcgfe9zb+8d/uZc4bny1qPfNHPMa7vruSmjPHlSiZFcrFYCVVO+E0vnzrHVz+xu0lWd/1Qzdw1dK7qR3yppKszwrjYrCS6TPmBO68/w7Oe0Nbp/OeOfgyU//hYzy8t431+19j58GXO53/wfq9fGfNMmqHDi1lXOuEi8FKY8oZfPf/fsqg2vq8D+9ufYUv7JrIF3ZN5J+u+ByxZj1fO2kS14w5mw9dfy2P7m3tdPWn9h3A5Y88TM3E8eVIb0foshgk3S5pt6R1OWODJT0oaUt2OyjnseskNUvaJOnCcgW36rH37ydz6U/u4eS++d+SfLltL2cvncvas2DtWVB37+rDHh98xwouv+kzjHv4E+xufaXD5/nQgFeZsnAtredNKml+SxXyiuHHwNQjxuYByyOiAVie/Y6k8cBMYEK2zM2SakuW1qrOa9Mns/09tVx/58c63CV4+4+u4ZSrH+10PcO/9wgnXPwkf/fv19IaHe+KXD90A2fd+Fva3jWxqNzWuS6LISJ+DTx/xPB0YGF2fyEwI2d8cUTsi4ingWZgcomyWhU65nfPc9oPdnLCVx/h4mvmJo+fMf9KTvjayoLXN/IbKzjvM1dw2h1XdDjnW2/+LRfc8htqxzV0K7N1rbvnSgyPiJ0AEbFT0rBsfCSQ+09DSzZmf6VaNzW/fn/Az1Yy7fEPA7Bx7hAGPN2HUd9tIto6P35wmAjq71rJSffXc3L95Wy+5GZqlf77de3gp3jnvVu4YdJ7aX3hxaL/DjtcqQ8+Ks9Y3pMxJM2W1CSp6QDd+xCMVZ/WLVtp3bKVU69YzchvriAO7O/WetpefZVTrllJw4OX8XLb3rxzzulfw/y199Fn9KhiIlse3S2GXZJGAGS3u7PxFmB0zrxRwI58K4iIBRHRGBGNfanrZgyrWhHtP0Wuo+GTa/j6c2/vcMq4fvVM/p+txT2PJbpbDMuAWdn9WcA9OeMzJdVJGgs0AKuKi2hmPa3LYwySFgHnAUMktQDXA18Hlki6FHgGuBggItZLWgJsAA4CcyLiKHYwzawadFkMEfHRDh7KewGFiLgBuKGYUGaHPDV/CrcN/jaQ/zMS5145m/679yEe79lgf+V8BScrG/XtxymPiPe9cT23vvUtRGvbUR2MVJ8+1J/84uvXcmiNNi7YOIP+sw6+PucN272nWg7+SLSVjkTtuAZqjzuOmjPHUfPAEL4/ciUzBrzMfVsf5cB9b6bmzHHUHndcl6uqOfZYNn/nbTwxedHrY0tfGUT/y8TB7Tte/7HycDFYyahfP7b8ywD2TjmVuGkPbSGm/u6D7IsDACwfv4z77lvEpq+O58WPT+HFj09h37T0HYeaAQPY8uW3sPXDtx42/s7+29l8xfE98rf8rfM1H63sbnvmoQ4v7bbslXrmLp112NjBga08PX1BMnfBi8ezdNywZNwKczTXfHQxWNn96Z/Ppq0PvDBlP1svuK1b6zhj/pXU/6GNgXd2fs6FdcwXg7Wq8qYfrWDoLSsYuKr9g2wTvn8l77/kk7zaVviByMs+dS/Hfqo0F3+xrrkYrEed8tPLGf3NVdQ8tJaPXPDxTk+zzvXu+s30vcjnRPQUF4P1qNZBB6kZ2P6uROuGzVwy++oul/nJniF8sfEDtO7ZU+54lnExWI8Z+PsDDBm+h/1vHQNATX09Led3frmOuTsnsegj76P1T0ee+W/l5A84WY+pu3c1dffmDNTWwvH5z5wEuHL7FJqvPh2tW1v+cHYYv2KwHtd84xT6jDkB1fVjasPGvHP+9bnTeWpOA3rYpVAJLgbrcad/byet2/9A6/Mv8OiC9PqN//taDStmnA6rnqxAOgN/jsEqTaKm7vDrcUQEsc8X7ym1o/kcg48xWGVF0La34+MMVhnelTCzhIvBzBIuBjNLuBjMLOFiMLOEi8HMEi4GM0u4GMws4WIws4SLwcwSLgYzS7gYzCzhYjCzhIvBzBIuBjNLuBjMLOFiMLOEi8HMEi4GM0u4GMws0WUxSLpd0m5J63LGviJpu6S12c+0nMeuk9QsaZOkC8sV3MzKp5BXDD8GpuYZvykiJmY/PweQNB6YCUzIlrlZUuffQWZmVafLYoiIXwOFfnHgdGBxROyLiKeBZmByEfnMrAKKOcZwlaQnsl2NQdnYSODZnDkt2VhC0mxJTZKaDuAvFzGrJt0thh8AJwMTgZ3A/Gxceebm/aqriFgQEY0R0diXunxTzKxCulUMEbErIlojog34IX/ZXWgBRudMHQXsKC6imfW0bhWDpBE5v14EHHrHYhkwU1KdpLFAA7CquIhm1tO6/O5KSYuA84AhklqA64HzJE2kfTdhG/BpgIhYL2kJsAE4CMyJiNbyRDezcvG3XZv9jTiab7v2Jx/NLOFiMLOEi8HMEi4GM0u4GMws4WIws4SLwcwSLgYzS7gYzCzhYjCzhIvBzBIuBjNLuBjMLOFiMLOEi8HMEi4GM0u4GMws4WIws4SLwcwSLgYzS7gYzCzhYjCzhIvBzBIuBjNLuBjMLOFiMLOEi8HMEi4GM0u4GMws4WIws4SLwcwSLgYzS7gYzCzRZTFIGi3pV5I2Slov6bPZ+GBJD0rakt0OylnmOknNkjZJurCcf4CZlV4hrxgOAnMjYhwwBZgjaTwwD1geEQ3A8ux3ssdmAhOAqcDNkmrLEd7MyqPLYoiInRHxWHb/JWAjMBKYDizMpi0EZmT3pwOLI2JfRDwNNAOTSx3czMrnqI4xSBoDnAWsBIZHxE5oLw9gWDZtJPBszmIt2ZiZ9RIFF4OkY4ClwNURsaezqXnGIs/6ZktqktR0gH2FxjCzHlBQMUjqS3sp3BkRd2XDuySNyB4fAezOxluA0TmLjwJ2HLnOiFgQEY0R0diXuu7mN7MyKORdCQG3ARsj4sach5YBs7L7s4B7csZnSqqTNBZoAFaVLrKZlVufAuacA3wCeFLS2mzsi8DXgSWSLgWeAS4GiIj1kpYAG2h/R2NORLSWPLmZlU2XxRARD5H/uAHA+R0scwNwQxG5zKyC/MlHM0u4GMws4WIws4SLwcwSLgYzS7gYzCzhYjCzhIvBzBIuBjNLuBjMLOFiMLOEi8HMEi4GM0u4GMws4WIws4SLwcwSLgYzS7gYzCzhYjCzhIvBzBIuBjNLuBjMLOFiMLOEi8HMEi4GM0u4GMws4WIws4SLwcwSLgYzS7gYzCzhYjCzhIvBzBIuBjNLuBjMLNFlMUgaLelXkjZKWi/ps9n4VyRtl7Q2+5mWs8x1kpolbZJ0YTn/ADMrvT4FzDkIzI2IxyQdC6yR9GD22E0R8e3cyZLGAzOBCcDxwC8lnRoRraUMbmbl0+UrhojYGRGPZfdfAjYCIztZZDqwOCL2RcTTQDMwuRRhzaxnHNUxBkljgLOAldnQVZKekHS7pEHZ2Ejg2ZzFWshTJJJmS2qS1HSAfUcd3MzKp+BikHQMsBS4OiL2AD8ATgYmAjuB+Yem5lk8koGIBRHRGBGNfak76uBmVj4FFYOkvrSXwp0RcRdAROyKiNaIaAN+yF92F1qA0TmLjwJ2lC6ymZVbIe9KCLgN2BgRN+aMj8iZdhGwLru/DJgpqU7SWKABWFW6yGZWboW8K3EO8AngSUlrs7EvAh+VNJH23YRtwKcBImK9pCXABtrf0ZjjdyTMehdFJLv/PR9C+iPwCvBcpbMUYAi9Iyf0nqy9JSf0nqz5cp4YEUMLWbgqigFAUlNENFY6R1d6S07oPVl7S07oPVmLzemPRJtZwsVgZolqKoYFlQ5QoN6SE3pP1t6SE3pP1qJyVs0xBjOrHtX0isHMqkTFi0HS1Oz07GZJ8yqd50iStkl6Mju1vCkbGyzpQUlbsttBXa2nDLlul7Rb0rqcsQ5zVfJU+A6yVt1p+51cYqCqtmuPXAohIir2A9QCTwEnAf2Ax4HxlcyUJ+M2YMgRY98E5mX35wHfqECuc4FJwLqucgHjs21bB4zNtnlthbN+Bfh8nrkVywqMACZl948FNmd5qmq7dpKzZNu00q8YJgPNEbE1IvYDi2k/bbvaTQcWZvcXAjN6OkBE/Bp4/ojhjnJV9FT4DrJ2pGJZo+NLDFTVdu0kZ0eOOmeli6GgU7QrLIAHJK2RNDsbGx4RO6H9PxIwrGLpDtdRrmrdzt0+bb/cjrjEQNVu11JeCiFXpYuhoFO0K+yciJgEfACYI+ncSgfqhmrczkWdtl9OeS4x0OHUPGM9lrXUl0LIVeliqPpTtCNiR3a7G7ib9pdguw6dXZrd7q5cwsN0lKvqtnNU6Wn7+S4xQBVu13JfCqHSxbAaaJA0VlI/2q8VuazCmV4naUB2nUskDQAuoP308mXArGzaLOCeyiRMdJSr6k6Fr8bT9ju6xABVtl175FIIPXG0t4sjrNNoP6r6FPClSuc5IttJtB/NfRxYfygf8CZgObAlux1cgWyLaH+5eID2fxEu7SwX8KVsG28CPlAFWf8DeBJ4Ivsfd0SlswLvov0l9hPA2uxnWrVt105ylmyb+pOPZpao9K6EmVUhF4OZJVwMZpZwMZhZwsVgZgkXg5klXAxmlnAxmFni/wEiKCyqrMV8ZQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "aa = masks.reshape(masks.shape[0], op['Ly'], op['Lx'])\n",
+    "plt.imshow(aa[6])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "suite2p",
+   "language": "python",
+   "name": "suite2p"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -231,6 +231,8 @@ def run_plane(ops, ops_path=None):
         ops, stat = extraction.extract(ops, cell_pix, cell_masks, neuropil_masks, stat)
         print('----------- Total %0.2f sec.'%(time.time()-t11))
 
+        ops['neuropil_masks'] = neuropil_masks.reshape(neuropil_masks.shape[0], ops['Ly'], ops['Lx'])
+
         ######## ROI CLASSIFICATION ##############
         t11=time.time()
         print('----------- CLASSIFICATION')


### PR DESCRIPTION
Closes #409 

Adds a "neuropil_masks" key to the ops dictionary, to make it possible for users to visualize the neuropil mask data.  Demonstration of usage can be seen in this [notebook](https://github.com/MouseLand/suite2p/blob/issue-409/jupyter/view_neuropil_masks.ipynb).

Best wishes,

Nick