### PR TITLE
Split developer_docs to smaller sections

### DIFF
--- a/docs/developer_doc.rst
+++ b/docs/developer_doc.rst
@@ -14,22 +14,29 @@ may get an incorrect version number. To fix this issue, one should use the follo
 Testing
 ~~~~~~~~~~~~~~~~~~~~~
 
-Before contributing to Suite2P, please make sure your changes pass all our tests. To run the tests (located in
+Before contributing to Suite2P, please make sure your changes pass all our tests.
+
+Downloading Test Data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To run the tests (located in
 the ``tests`` subdirectory of your working ``suite2p`` directory) , you'll first need to download our test data.
 Suite2p depends on `dvc`_ to download the test data.
 
 .. note::
 
-    Before testing, make sure you have dvc installed:
+    Before testing, make sure you have dvc and pydrive2 installed. Navigate to the suite2p
+    directory and use the following command to install both dvc and pydrive2.
 
     .. prompt:: bash
 
-        pip install dvc
-    The command above may prompt you to install ``pydrive2``. Install it and you should be good to go.
+        pip install -e .[data]
+
+    zsh users should use the following:
 
     .. prompt:: bash
 
-        pip install pydrive2
+        pip install -e .\[docs\]
 
 
 Use to following command to download the test data into the ``data`` subdirectory of your working ``suite2p`` directory.
@@ -37,6 +44,9 @@ Use to following command to download the test data into the ``data`` subdirector
 .. prompt:: bash
 
     dvc pull
+
+Running the tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Tests can then be easily run with the following command:
 

--- a/docs/registration.rst
+++ b/docs/registration.rst
@@ -209,8 +209,8 @@ To run the script, use the following command:
 
     reg_metrics <INSERT_OPS_DATA_PATH> # Add --tiff_list <INSERT_INPUT_TIF_FILENAME_HERE>.tif to select a subset of tifs
 
-Once you run the ``reg_metrics`` command, registration will be performed for the input file and
-an output similar to the following will be shown:
+Once you run the ``reg_metrics`` command, registration will be performed for the input file with default
+ops parameters and an output similar to the following will be shown:
 
 ::
 
@@ -224,6 +224,14 @@ For each ``nplane``, these statistics (Average and Max) are calculated across PC
 If the registration works perfectly and most of the motion is removed from the registered dataset, these scores
 should all be very close to zero.
 
+.. Important::
+
+    Make sure to also inspect the registered video to check the quality of registration. You can see an example
+    of how this is done in the GUI `here <https://youtu.be/M7UjvCUn74Y?t=810>`_.
+
+You may notice that upon visual inspection, the registered video may look fine/contain little motion even
+if the statistics are not close to zero. You should always visually check the registration output and prioritize
+what your eyes say over what the CLI script reports.
 
 .. note::
 


### PR DESCRIPTION
Minor PR having to do with updates to developer docs. Does the following:

- splits testing section into downloading/running tests
- replaces dvc/pydrive installs with just `-e .[data]`
- additional comments in registration CLI script docs portion