### PR TITLE
Added smoke CLI test for suite2p command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+dist: xenial
+services:
+  - xvfb
 jobs:
   include:
   - name: Python 3.7.1 on Linux
@@ -41,7 +44,6 @@ install:
 - dvc pull -r gdrive-travis
 - pip install coveralls
 script:
-- xvfb-run make test
 - coverage run --source=suite2p setup.py test
 after_success: coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
 - dvc pull -r gdrive-travis
 - pip install coveralls
 script:
+- xvfb-run make test
 - coverage run --source=suite2p setup.py test
 after_success: coveralls
 deploy:

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from time import sleep
 
+
 def test_cli_help_test_appears_when_suite2p_is_called(capfd):
     os.system('suite2p --help')
     captured = capfd.readouterr()
@@ -47,6 +48,7 @@ def test_cli_reg_metrics_runs_with_output(capfd, tmpdir):
 def test_cli_suite2p_gui_runs_when_is_called_locally():
     s2p = subprocess.Popen(['python', '-m', 'suite2p'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     sleep(10)
+    assert s2p.poll() is None  # Make sure process is running
     s2p.terminate()
     output, err = s2p.communicate(b'\n')
     assert "Error" not in err.decode('ascii')

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -1,5 +1,6 @@
 import os
-
+import subprocess
+from time import sleep
 
 def test_cli_help_test_appears_when_suite2p_is_called(capfd):
     os.system('suite2p --help')
@@ -41,3 +42,11 @@ def test_cli_reg_metrics_runs_with_output(capfd, tmpdir):
     os.system(f'reg_metrics data/test_data/ --tiff_list input_1500.tif --do_registration 2 --save_path0 {tmpdir}')
     captured = capfd.readouterr()
     assert captured.out
+
+
+def test_cli_suite2p_gui_runs_when_is_called_locally():
+    s2p = subprocess.Popen(['python', '-m', 'suite2p'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sleep(10)
+    s2p.terminate()
+    output, err = s2p.communicate(b'\n')
+    assert "Error" not in err.decode('ascii')

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -9,13 +9,19 @@ def test_cli_help_test_appears_when_suite2p_is_called(capfd):
     assert 'parameters' in captured.out
 
 
+def test_cli_version_test_appears_when_suite2p_is_called_locally(capfd):
+    os.system('python -m suite2p --version')
+    captured = capfd.readouterr()
+    assert 'suite2p v' in captured.out
+
+
 def test_cli_version_test_appears_when_suite2p_is_called(capfd):
     os.system('suite2p --version')
     captured = capfd.readouterr()
     assert 'suite2p v' in captured.out
 
 
-def test_cli_help_test_appears_when_suite2p_is_called2(capfd):
+def test_cli_help_test_appears_when_suite2p_is_called_locally(capfd):
     os.system('python -m suite2p --help')
     captured = capfd.readouterr()
     assert 'Suite2p' in captured.out

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -9,6 +9,12 @@ def test_cli_help_test_appears_when_suite2p_is_called(capfd):
     assert 'parameters' in captured.out
 
 
+def test_cli_version_test_appears_when_suite2p_is_called(capfd):
+    os.system('suite2p --version')
+    captured = capfd.readouterr()
+    assert 'suite2p v' in captured.out
+
+
 def test_cli_help_test_appears_when_suite2p_is_called2(capfd):
     os.system('python -m suite2p --help')
     captured = capfd.readouterr()


### PR DESCRIPTION
PR addresses #473:

- Added smoke test for general `suite2p` command. There were problems with using `os.system` as suite2p hangs indefinitely (since it closes when GUI is closed) and prevents the running of our other tests. Unlike `os.system`, `subprocess.Popen` doesn't block and can be terminated by the developer. The sleep(10) was just set so there's enough time for the suite2p window to open up.  
- CLI version output tests have been added