### PR TITLE
added 'suite2p_version' key in ops.

### DIFF
--- a/suite2p/__init__.py
+++ b/suite2p/__init__.py
@@ -1,9 +1,7 @@
-from importlib_metadata import metadata as _metadata
-
+from .version import version
 from .run_s2p import run_s2p, default_ops, builtin_classfile, user_classfile
 from .gui import run as run_gui
 from .detection import ROI
 
-name = "suite2p"
-version = _metadata('suite2p')['version']
 
+name = "suite2p"

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy.io import savemat
 
 from . import extraction, io, registration, detection, classification
+from . import version
 
 try:
     from haussmeister import haussio
@@ -25,6 +26,9 @@ user_classfile = Path.home().joinpath('.suite2p/classifiers/classifier_user.npy'
 def default_ops():
     """ default options to run pipeline """
     return {
+        # Suite2p version
+        'suite2p_version': version,
+
         # file paths
         'look_one_level_down': False,  # whether to look in all subfolders when searching for tiffs
         'fast_disk': [],  # used to store temporary binary file, defaults to save_path0

--- a/suite2p/version.py
+++ b/suite2p/version.py
@@ -1,0 +1,4 @@
+from importlib_metadata import metadata as _metadata
+
+
+version = _metadata('suite2p')['version']

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -12,3 +12,10 @@ def test_cli_provides_correct_package_number(capfd):
     os.system('suite2p --version')
     captured = capfd.readouterr()
     assert metadata('suite2p')['version'] in captured.out
+
+
+def test_ops_suite2p_version_matches_cli_version_number(capfd):
+    os.system('suite2p --version')
+    captured = capfd.readouterr()
+    ops_version = suite2p.default_ops()['suite2p_version']
+    assert ops_version in captured.out


### PR DESCRIPTION
Adds `ops['suite2p_version']` to default_ops(), to make it easier to tell what version of suite2p was used to process a dataset.

Closes #456 

Best wishes,

Nick