### PR TITLE
Adds Mesoscan test. Reinstates classify.py. Refactors test/utils funcs. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 - dvc pull -r gdrive-travis
 - pip install coveralls
 script:
-- coverage run --source=suite2p setup.py test
+- travis_wait 30 coverage run --source=suite2p setup.py test
 after_success: coveralls
 deploy:
   skip_cleanup: true

--- a/data/test_data.dvc
+++ b/data/test_data.dvc
@@ -1,3 +1,3 @@
 outs:
-- md5: 97e9a5cfa0c50fb44dc13e8c4d7a4569.dir
+- md5: 73cb45f984f66ab9c3ab0c9f771c6619.dir
   path: test_data

--- a/data/test_data.dvc
+++ b/data/test_data.dvc
@@ -1,3 +1,3 @@
 outs:
-- md5: 73cb45f984f66ab9c3ab0c9f771c6619.dir
+- md5: 89ca0a8b78fe9ab8a6f688b4e25c72aa.dir
   path: test_data

--- a/suite2p/__init__.py
+++ b/suite2p/__init__.py
@@ -1,6 +1,6 @@
 from importlib_metadata import metadata as _metadata
 
-from .run_s2p import run_s2p, default_ops, builtin_classfile, user_classfile
+from .run_s2p import run_s2p, default_ops
 from .gui import run as run_gui
 from .detection import ROI
 

--- a/suite2p/classification/__init__.py
+++ b/suite2p/classification/__init__.py
@@ -1,2 +1,2 @@
 from .classifier import Classifier
-from .classify import classify
+from .classify import classify, builtin_classfile, user_classfile

--- a/suite2p/classification/__init__.py
+++ b/suite2p/classification/__init__.py
@@ -1,1 +1,2 @@
 from .classifier import Classifier
+from .classify import classify

--- a/suite2p/classification/classify.py
+++ b/suite2p/classification/classify.py
@@ -3,14 +3,14 @@ from pathlib import Path
 from typing import Union, Sequence
 from .classifier import Classifier
 
+builtin_classfile = Path(__file__).joinpath('../../classifiers/classifier.npy').resolve()
+user_classfile = Path.home().joinpath('.suite2p/classifiers/classifier_user.npy')
+
 
 def classify(stat: np.ndarray,
-             classfile: Union[str, Path] = None, keys: Sequence[str] = ('npix_norm', 'compact', 'skew'),
+             classfile: Union[str, Path] = None,
+             keys: Sequence[str] = ('npix_norm', 'compact', 'skew'),
              ):
     """Returns array of classifier output from classification process."""
-
-    for key in keys:
-        if key not in stat[0]:
-            raise KeyError("Key '{}' not found in stats dictionary.".format(key))
-
+    keys = list(set(keys).intersection(set(stat[0])))
     return Classifier(classfile, keys=keys).run(stat)

--- a/suite2p/classification/classify.py
+++ b/suite2p/classification/classify.py
@@ -1,0 +1,16 @@
+import numpy as np
+from pathlib import Path
+from typing import Union, Sequence
+from .classifier import Classifier
+
+
+def classify(stat: np.ndarray,
+             classfile: Union[str, Path] = None, keys: Sequence[str] = ('npix_norm', 'compact', 'skew'),
+             ):
+    """Returns array of classifier output from classification process."""
+
+    for key in keys:
+        if key not in stat[0]:
+            raise KeyError("Key '{}' not found in stats dictionary.".format(key))
+
+    return Classifier(classfile, keys=keys).run(stat)

--- a/suite2p/classification/classify.py
+++ b/suite2p/classification/classify.py
@@ -8,7 +8,7 @@ user_classfile = Path.home().joinpath('.suite2p/classifiers/classifier_user.npy'
 
 
 def classify(stat: np.ndarray,
-             classfile: Union[str, Path] = None,
+             classfile: Union[str, Path],
              keys: Sequence[str] = ('npix_norm', 'compact', 'skew'),
              ):
     """Returns array of classifier output from classification process."""

--- a/suite2p/detection/detect.py
+++ b/suite2p/detection/detect.py
@@ -6,7 +6,7 @@ from . import sourcery, sparsedetect, chan2detect
 from .stats import roi_stats
 from .masks import create_cell_mask, create_neuropil_masks, create_cell_pix
 from ..io.binary import BinaryFile
-from ..classification import Classifier
+from ..classification import classify
 
 
 def detect(ops, classfile: Path):
@@ -90,7 +90,7 @@ def select_rois(mov: np.ndarray, dy: int, dx: int, Ly: int, Lx: int, max_overlap
         if len(stats) == 0:
             iscell = np.zeros((0, 2))
         else:
-            iscell = Classifier(classfile=classfile,keys=['npix_norm', 'compact', 'skew']).run(stats)
+            iscell = classify(stat=stats, classfile=classfile)
         np.save(Path(ops['save_path']).joinpath('iscell.npy'), iscell)
         ic = (iscell[:,0]>ops['preclassify']).flatten().astype(np.bool)
         stats = stats[ic]

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -18,8 +18,6 @@ except ImportError:
 from functools import partial
 from pathlib import Path
 print = partial(print,flush=True)
-builtin_classfile = Path(__file__).joinpath('../classifiers/classifier.npy').resolve()
-user_classfile = Path.home().joinpath('.suite2p/classifiers/classifier_user.npy')
 
 
 def default_ops():
@@ -204,7 +202,8 @@ def run_plane(ops, ops_path=None):
 
         # Select file for classification
         ops_classfile = ops.get('classifier_path')
-
+        builtin_classfile = classification.builtin_classfile
+        user_classfile = classification.user_classfile
         if ops['use_builtin_classifier']:
             print(f'NOTE: Applying builtin classifier at {str(builtin_classfile)}')
             classfile = builtin_classfile

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -240,7 +240,7 @@ def run_plane(ops, ops_path=None):
         else:
             np.save(
                 Path(ops['save_path']).joinpath('iscell.npy'),
-                classification.Classifier(classfile=classfile, keys=['npix_norm', 'compact', 'skew']).run(stat),
+                classification.classify(stat=stat, classfile=classfile)
             )
 
         print('----------- Total %0.2f sec.'%(time.time()-t11))

--- a/tests/regression/test_classification_pipeline.py
+++ b/tests/regression/test_classification_pipeline.py
@@ -3,7 +3,7 @@ Tests for the Suite2p Classification module.
 """
 
 import numpy as np
-from suite2p import classification, builtin_classfile
+from suite2p import classification
 
 
 def get_stat_iscell(data_dir_path):
@@ -19,5 +19,5 @@ def test_classification_output(test_ops, data_dir):
     """
     test_ops['save_path'] = test_ops['save_path0']
     stat, expected_output = get_stat_iscell(data_dir)
-    iscell = classification.classify(stat, classfile=builtin_classfile)
+    iscell = classification.classify(stat, classfile=classification.builtin_classfile)
     assert np.allclose(iscell, expected_output, atol=2e-4)

--- a/tests/regression/test_classification_pipeline.py
+++ b/tests/regression/test_classification_pipeline.py
@@ -19,5 +19,5 @@ def test_classification_output(test_ops, data_dir):
     """
     test_ops['save_path'] = test_ops['save_path0']
     stat, expected_output = get_stat_iscell(data_dir)
-    iscell = classification.Classifier(classfile=builtin_classfile,keys=['npix_norm', 'compact', 'skew']).run(stat)
+    iscell = classification.classify(stat, classfile=builtin_classfile)
     assert np.allclose(iscell, expected_output, atol=2e-4)

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -89,10 +89,10 @@ def test_detection_output_2plane2chan(test_ops):
     ops[0]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p0.npy'))
     ops[1]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p1.npy'))
     detect_wrapper(ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         ['redcell'],
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes
     ))

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -4,7 +4,8 @@ Tests for the Suite2p Detection module.
 
 import numpy as np
 import utils
-from suite2p import detection, builtin_classfile
+from suite2p import detection
+from suite2p.classification import builtin_classfile
 
 
 def prepare_for_detection(op, input_file_name_list, dimensions):

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -91,8 +91,8 @@ def test_detection_output_2plane2chan(test_ops):
     detect_wrapper(ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        ['redcell'],
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes
+        output_root=test_ops['save_path0'],
+        outputs_to_check=['redcell'],
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes=nplanes
     ))

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -106,10 +106,10 @@ def test_extraction_output_1plane1chan(test_ops):
     extract_wrapper(ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        ['F', 'Fneu', 'stat', 'spks'],
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes
+        output_root=test_ops['save_path0'],
+        outputs_to_check=['F', 'Fneu', 'stat', 'spks'],
+        test_data_dir= test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes=nplanes
     ))
 
 
@@ -133,8 +133,8 @@ def test_extraction_output_2plane2chan(test_ops):
     extract_wrapper(ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        ['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks'],
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes
+        output_root=test_ops['save_path0'],
+        outputs_to_check=['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks'],
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes=nplanes
     ))

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -104,12 +104,12 @@ def test_extraction_output_1plane1chan(test_ops):
         (404, 360)
     )
     extract_wrapper(ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         ['F', 'Fneu', 'stat', 'spks'],
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes
     ))
 
 
@@ -131,10 +131,10 @@ def test_extraction_output_2plane2chan(test_ops):
     ops[0]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p0.npy'))
     ops[1]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p1.npy'))
     extract_wrapper(ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         ['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks'],
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes
     ))

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -95,10 +95,10 @@ def test_mesoscan_2plane_2z(test_ops):
     """
     with open('data/test_data/mesoscan/ops.json') as f:
         meso_ops = json.load(f)
+    test_ops['data_path'] = [Path(test_ops['data_path'][0]).joinpath('mesoscan')]
     for key in meso_ops.keys():
-        if key not in ['save_path0', 'do_registration', 'roidetect']:
+        if key not in ['data_path', 'save_path0', 'do_registration', 'roidetect']:
             test_ops[key] = meso_ops[key]
-    test_ops['data_path'] = test_ops['data_path'].joinpath('mesoscan')
     suite2p.run_s2p(ops=test_ops)
     assert all(utils.check_output(
         output_root=test_ops['save_path0'],

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -27,23 +27,21 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     })
     suite2p.run_s2p(ops=test_ops)
 
-    outputs_to_check = ['F', 'Fneu', 'spks', 'iscell']
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         output_root=test_ops['save_path0'],
-        outputs_to_check=outputs_to_check,
+        outputs_to_check=get_outputs_to_check(test_ops['nchannels']),
         test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
         nplanes=nplanes,
     ))
-
     # Read Nwb data and make sure it's identical to output data
     stat, ops, F, Fneu, spks, iscell, probcell, redcell, probredcell = \
         io.read_nwb(str(Path(test_ops['save_path0']).joinpath('suite2p/ophys.nwb')))
     assert all(utils.compare_list_of_outputs(
         0,
-        outputs_to_check,
-        utils.get_list_of_output_data(outputs_to_check, test_ops['save_path0'], 0),
-        [F, Fneu, spks, np.stack([iscell.astype(np.float32), probcell.astype(np.float32)]).T],
+        get_outputs_to_check(test_ops['nchannels']),
+        utils.get_list_of_output_data(get_outputs_to_check(test_ops['nchannels']), test_ops['save_path0'], 0),
+        [F, Fneu, np.stack([iscell.astype(np.float32), probcell.astype(np.float32)]).T, spks, stat],
     ))
 
 

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -30,10 +30,10 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     outputs_to_check = ['F', 'Fneu', 'spks', 'iscell']
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        outputs_to_check,
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
-        nplanes,
+        output_root=test_ops['save_path0'],
+        outputs_to_check=outputs_to_check,
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+        nplanes=nplanes,
     ))
 
     # Read Nwb data and make sure it's identical to output data
@@ -62,10 +62,10 @@ def test_2plane_2chan_with_batches(test_ops):
     suite2p.run_s2p(ops=test_ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        get_outputs_to_check(test_ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
-        nplanes,
+        output_root=test_ops['save_path0'],
+        outputs_to_check=get_outputs_to_check(test_ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+        nplanes=nplanes,
     ))
 
 
@@ -82,10 +82,10 @@ def test_1plane_2chan_sourcery(test_ops):
     suite2p.run_s2p(ops=test_ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        get_outputs_to_check(test_ops['nchannels']),
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes,
+        output_root=test_ops['save_path0'],
+        outputs_to_check=get_outputs_to_check(test_ops['nchannels']),
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes=nplanes,
     ))
 
 

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -28,13 +28,12 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     suite2p.run_s2p(ops=test_ops)
 
     outputs_to_check = ['F', 'Fneu', 'spks', 'iscell']
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         outputs_to_check,
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
-        added_tag='1500'
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+        nplanes,
     ))
 
     # Read Nwb data and make sure it's identical to output data
@@ -61,13 +60,12 @@ def test_2plane_2chan_with_batches(test_ops):
         'reg_tif_chan2': True,
     })
     suite2p.run_s2p(ops=test_ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         get_outputs_to_check(test_ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
-        added_tag='1500'
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+        nplanes,
     ))
 
 
@@ -82,22 +80,22 @@ def test_1plane_2chan_sourcery(test_ops):
         'keep_movie_raw': True
     })
     suite2p.run_s2p(ops=test_ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         get_outputs_to_check(test_ops['nchannels']),
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes,
     ))
 
 
-def test_mesoscan_2plane_2z(test_ops):
-    """
-    Tests for case with 2 planes and 2 ROIs for a mesoscan.
-    """
-    with open('data/test_data/mesoscan/ops.json') as f:
-        meso_ops = json.load(f)
-    for key in meso_ops.keys():
-        if key not in ['data_path', 'save_path0', 'do_registration', 'roidetect']:
-            test_ops[key] = meso_ops[key]
-    suite2p.run_s2p(ops=test_ops)
+# def test_mesoscan_2plane_2z(test_ops):
+#     """
+#     Tests for case with 2 planes and 2 ROIs for a mesoscan.
+#     """
+#     with open('data/test_data/mesoscan/ops.json') as f:
+#         meso_ops = json.load(f)
+#     for key in meso_ops.keys():
+#         if key not in ['data_path', 'save_path0', 'do_registration', 'roidetect']:
+#             test_ops[key] = meso_ops[key]
+#     suite2p.run_s2p(ops=test_ops)

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -89,13 +89,20 @@ def test_1plane_2chan_sourcery(test_ops):
     ))
 
 
-# def test_mesoscan_2plane_2z(test_ops):
-#     """
-#     Tests for case with 2 planes and 2 ROIs for a mesoscan.
-#     """
-#     with open('data/test_data/mesoscan/ops.json') as f:
-#         meso_ops = json.load(f)
-#     for key in meso_ops.keys():
-#         if key not in ['data_path', 'save_path0', 'do_registration', 'roidetect']:
-#             test_ops[key] = meso_ops[key]
-#     suite2p.run_s2p(ops=test_ops)
+def test_mesoscan_2plane_2z(test_ops):
+    """
+    Tests for case with 2 planes and 2 ROIs for a mesoscan.
+    """
+    with open('data/test_data/mesoscan/ops.json') as f:
+        meso_ops = json.load(f)
+    for key in meso_ops.keys():
+        if key not in ['save_path0', 'do_registration', 'roidetect']:
+            test_ops[key] = meso_ops[key]
+    test_ops['data_path'] = test_ops['data_path'].joinpath('mesoscan')
+    suite2p.run_s2p(ops=test_ops)
+    assert all(utils.check_output(
+        output_root=test_ops['save_path0'],
+        outputs_to_check=get_outputs_to_check(test_ops['nchannels']),
+        test_data_dir=test_ops['data_path'][0].joinpath('suite2p'),
+        nplanes=test_ops['nplanes']*test_ops['nrois'],
+    ))

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -5,8 +5,7 @@ Class that tests common use cases for pipeline.
 from suite2p import io
 from pathlib import Path
 import numpy as np
-import suite2p
-import utils
+import suite2p, json, utils
 
 
 def get_outputs_to_check(n_channels):
@@ -90,3 +89,15 @@ def test_1plane_2chan_sourcery(test_ops):
         test_ops['nplanes'],
         test_ops['nchannels'],
     ))
+
+
+def test_mesoscan_2plane_2z(test_ops):
+    """
+    Tests for case with 2 planes and 2 ROIs for a mesoscan.
+    """
+    with open('data/test_data/mesoscan/ops.json') as f:
+        meso_ops = json.load(f)
+    for key in meso_ops.keys():
+        if key not in ['data_path', 'save_path0', 'do_registration', 'roidetect']:
+            test_ops[key] = meso_ops[key]
+    suite2p.run_s2p(ops=test_ops)

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -58,14 +58,14 @@ def test_2plane_2chan_with_batches(test_ops):
                 'reg_tif': True,
                 'reg_tif_chan2': True,
             })
-            suite2p.run_s2p(ops=test_ops)
-            nplanes = test_ops['nplanes']
-            assert all(utils.check_output(
-                output_root=test_ops['save_path0'],
-                outputs_to_check=get_outputs_to_check(test_ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
-                test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
-                nplanes=nplanes,
-            ))
+        suite2p.run_s2p(ops=test_ops)
+        nplanes = test_ops['nplanes']
+        assert all(utils.check_output(
+            output_root=test_ops['save_path0'],
+            outputs_to_check=get_outputs_to_check(test_ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
+            test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+            nplanes=nplanes,
+        ))
 
 
 def test_1plane_2chan_sourcery(test_ops):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,13 +41,12 @@ def check_dict_dicts_all_close(first_dict, second_dict) -> Iterator[bool]:
             yield np.allclose(gt_dict[k], output_dict[k], rtol=r_tol, atol=a_tol)
 
 
-def get_list_of_test_data(outputs_to_check, test_data_dir, nplanes, nchannels, added_tag, curr_plane):
+def get_list_of_test_data(outputs_to_check, test_plane_dir):
     """
     Gets list of test_data from test data directory matching provided nplanes, nchannels, and added_tag. Returns
     all test_data for given plane number.
     """
     test_data_list = []
-    test_plane_dir = test_data_dir.joinpath(f'{nplanes}plane{nchannels}chan{added_tag}/suite2p/plane{curr_plane}')
     for output in outputs_to_check:
         if 'reg_tif' in output:
             filename = np.concatenate([imread(tif) for tif in glob(str(test_plane_dir.joinpath(f"{output}/*.tif")))])
@@ -78,10 +77,11 @@ def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int, nch
     as the ground truth outputs.
     """
     for i in range(nplanes):
+        test_plane_dir = test_data_dir.joinpath(f'{nplanes}plane{nchannels}chan{added_tag}/suite2p/plane{i}')
         yield all(compare_list_of_outputs(
             i,
             outputs_to_check,
-            get_list_of_test_data(outputs_to_check, test_data_dir, nplanes, nchannels, added_tag, i),
+            get_list_of_test_data(outputs_to_check, test_plane_dir),
             get_list_of_output_data(outputs_to_check, output_root, i),
         ))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,13 +71,13 @@ def get_list_of_output_data(outputs_to_check, output_root, curr_plane):
     return output_data_list
 
 
-def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int, nchannels: int, added_tag="") -> Iterator[bool]:
+def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int) -> Iterator[bool]:
     """
     Helper function to check if outputs given by a test are exactly the same
     as the ground truth outputs.
     """
     for i in range(nplanes):
-        test_plane_dir = test_data_dir.joinpath(f'{nplanes}plane{nchannels}chan{added_tag}/suite2p/plane{i}')
+        test_plane_dir = test_data_dir.joinpath(f'plane{i}')
         yield all(compare_list_of_outputs(
             i,
             outputs_to_check,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,4 +91,7 @@ def compare_list_of_outputs(plane_num, output_name_list, data_list_one, data_lis
         if output == 'stat':  # where the elements of npy arrays are dictionaries (e.g: stat.npy)
             yield check_dict_dicts_all_close(data1, data2)
         else:
+            if output == 'iscell':  # just check the first column; are cells/noncells classified the same way?
+                data1 = data1[:, 0]
+                data2 = data2[:, 0]
             yield np.allclose(data1, data2, rtol=r_tol, atol=a_tol)


### PR DESCRIPTION
This PR addresses the following: 

1. Adds a test for the mesoscan data Marius provided. I ended up generating the prior output from the following commit eaeddbb6cd32322b051c0263e38a0fc3abfd9a3d. 7bbbf57815c4aaac19ead79e1d31565663687f3b, the commit corresponding to the release of v0.7.5 and also the commit i based much off the regression tests off, errored whenever preclassify was used. Later commits (like 142ed8bdac70061c8960bb0841b90a10faa3c705) that had preclassify working had an issue with the default keys parameter in classify not containing `skew` due to issue with mutable defaults (discussed [here](https://github.com/MouseLand/suite2p/pull/477#discussion_r461975893)). Skew's not added to stats until the extraction step so anytime preclassify was > 0, any classify() calls made later on in the pipeline would have keys=['npix_norm', 'compact'] only.
2. test/utils.py was refactored to work with checking the outputs of the mesoscan data. 
3. Added back classify.py with the classify func as requested [here](https://github.com/MouseLand/suite2p/pull/477#issuecomment-669308565). Classfiles are now defined in classify.py.