### PR TITLE
Reinstates classify.py. Refactors test/utils funcs.

### DIFF
--- a/data/test_data.dvc
+++ b/data/test_data.dvc
@@ -1,3 +1,3 @@
 outs:
-- md5: 97e9a5cfa0c50fb44dc13e8c4d7a4569.dir
+- md5: 7d4ff5a98131cf1a8ef1c5725caeb2e9.dir
   path: test_data

--- a/suite2p/__init__.py
+++ b/suite2p/__init__.py
@@ -1,5 +1,5 @@
 from .version import version
-from .run_s2p import run_s2p, default_ops, builtin_classfile, user_classfile
+from .run_s2p import run_s2p, default_ops
 from .gui import run as run_gui
 from .detection import ROI
 

--- a/suite2p/classification/__init__.py
+++ b/suite2p/classification/__init__.py
@@ -1,2 +1,2 @@
 from .classifier import Classifier
-from .classify import classify
+from .classify import classify, builtin_classfile, user_classfile

--- a/suite2p/classification/__init__.py
+++ b/suite2p/classification/__init__.py
@@ -1,1 +1,2 @@
 from .classifier import Classifier
+from .classify import classify

--- a/suite2p/classification/classify.py
+++ b/suite2p/classification/classify.py
@@ -3,14 +3,14 @@ from pathlib import Path
 from typing import Union, Sequence
 from .classifier import Classifier
 
+builtin_classfile = Path(__file__).joinpath('../../classifiers/classifier.npy').resolve()
+user_classfile = Path.home().joinpath('.suite2p/classifiers/classifier_user.npy')
+
 
 def classify(stat: np.ndarray,
-             classfile: Union[str, Path] = None, keys: Sequence[str] = ('npix_norm', 'compact', 'skew'),
+             classfile: Union[str, Path] = None,
+             keys: Sequence[str] = ('npix_norm', 'compact', 'skew'),
              ):
     """Returns array of classifier output from classification process."""
-
-    for key in keys:
-        if key not in stat[0]:
-            raise KeyError("Key '{}' not found in stats dictionary.".format(key))
-
+    keys = list(set(keys).intersection(set(stat[0])))
     return Classifier(classfile, keys=keys).run(stat)

--- a/suite2p/classification/classify.py
+++ b/suite2p/classification/classify.py
@@ -1,0 +1,16 @@
+import numpy as np
+from pathlib import Path
+from typing import Union, Sequence
+from .classifier import Classifier
+
+
+def classify(stat: np.ndarray,
+             classfile: Union[str, Path] = None, keys: Sequence[str] = ('npix_norm', 'compact', 'skew'),
+             ):
+    """Returns array of classifier output from classification process."""
+
+    for key in keys:
+        if key not in stat[0]:
+            raise KeyError("Key '{}' not found in stats dictionary.".format(key))
+
+    return Classifier(classfile, keys=keys).run(stat)

--- a/suite2p/classification/classify.py
+++ b/suite2p/classification/classify.py
@@ -8,7 +8,7 @@ user_classfile = Path.home().joinpath('.suite2p/classifiers/classifier_user.npy'
 
 
 def classify(stat: np.ndarray,
-             classfile: Union[str, Path] = None,
+             classfile: Union[str, Path],
              keys: Sequence[str] = ('npix_norm', 'compact', 'skew'),
              ):
     """Returns array of classifier output from classification process."""

--- a/suite2p/detection/detect.py
+++ b/suite2p/detection/detect.py
@@ -6,7 +6,7 @@ from . import sourcery, sparsedetect, chan2detect
 from .stats import roi_stats
 from .masks import create_cell_mask, create_neuropil_masks, create_cell_pix
 from ..io.binary import BinaryFile
-from ..classification import Classifier
+from ..classification import classify
 
 
 def detect(ops, classfile: Path):
@@ -90,7 +90,7 @@ def select_rois(mov: np.ndarray, dy: int, dx: int, Ly: int, Lx: int, max_overlap
         if len(stats) == 0:
             iscell = np.zeros((0, 2))
         else:
-            iscell = Classifier(classfile=classfile,keys=['npix_norm', 'compact', 'skew']).run(stats)
+            iscell = classify(stat=stats, classfile=classfile)
         np.save(Path(ops['save_path']).joinpath('iscell.npy'), iscell)
         ic = (iscell[:,0]>ops['preclassify']).flatten().astype(np.bool)
         stats = stats[ic]

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -20,8 +20,6 @@ except ImportError:
 from functools import partial
 from pathlib import Path
 print = partial(print,flush=True)
-builtin_classfile = Path(__file__).joinpath('../classifiers/classifier.npy').resolve()
-user_classfile = Path.home().joinpath('.suite2p/classifiers/classifier_user.npy')
 
 
 def default_ops():
@@ -198,7 +196,8 @@ def run_plane(ops, ops_path=None):
 
         # Select file for classification
         ops_classfile = ops.get('classifier_path')
-
+        builtin_classfile = classification.builtin_classfile
+        user_classfile = classification.user_classfile
         if ops['use_builtin_classifier']:
             print(f'NOTE: Applying builtin classifier at {str(builtin_classfile)}')
             classfile = builtin_classfile

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -230,7 +230,7 @@ def run_plane(ops, ops_path=None):
         t11=time.time()
         print('----------- CLASSIFICATION')
         if len(stat):
-            iscell = classification.Classifier(classfile=classfile, keys=['npix_norm', 'compact', 'skew']).run(stat)
+            iscell = classification.classify(stat=stat, classfile=classfile)
         else:
             iscell = np.zeros((0, 2))
         np.save(Path(ops['save_path']).joinpath('iscell.npy'), iscell)

--- a/tests/regression/test_classification_pipeline.py
+++ b/tests/regression/test_classification_pipeline.py
@@ -3,7 +3,7 @@ Tests for the Suite2p Classification module.
 """
 
 import numpy as np
-from suite2p import classification, builtin_classfile
+from suite2p import classification
 
 
 def get_stat_iscell(data_dir_path):
@@ -19,5 +19,5 @@ def test_classification_output(test_ops, data_dir):
     """
     test_ops['save_path'] = test_ops['save_path0']
     stat, expected_output = get_stat_iscell(data_dir)
-    iscell = classification.classify(stat, classfile=builtin_classfile)
+    iscell = classification.classify(stat, classfile=classification.builtin_classfile)
     assert np.allclose(iscell, expected_output, atol=2e-4)

--- a/tests/regression/test_classification_pipeline.py
+++ b/tests/regression/test_classification_pipeline.py
@@ -19,5 +19,5 @@ def test_classification_output(test_ops, data_dir):
     """
     test_ops['save_path'] = test_ops['save_path0']
     stat, expected_output = get_stat_iscell(data_dir)
-    iscell = classification.Classifier(classfile=builtin_classfile,keys=['npix_norm', 'compact', 'skew']).run(stat)
+    iscell = classification.classify(stat, classfile=builtin_classfile)
     assert np.allclose(iscell, expected_output, atol=2e-4)

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -89,10 +89,10 @@ def test_detection_output_2plane2chan(test_ops):
     ops[0]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p0.npy'))
     ops[1]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p1.npy'))
     detect_wrapper(ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         ['redcell'],
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes
     ))

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -4,7 +4,8 @@ Tests for the Suite2p Detection module.
 
 import numpy as np
 import utils
-from suite2p import detection, builtin_classfile
+from suite2p import detection
+from suite2p.classification import builtin_classfile
 
 
 def prepare_for_detection(op, input_file_name_list, dimensions):

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -91,8 +91,8 @@ def test_detection_output_2plane2chan(test_ops):
     detect_wrapper(ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        ['redcell'],
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes
+        output_root=test_ops['save_path0'],
+        outputs_to_check=['redcell'],
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes=nplanes
     ))

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -106,10 +106,10 @@ def test_extraction_output_1plane1chan(test_ops):
     extract_wrapper(ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        ['F', 'Fneu', 'stat', 'spks'],
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes
+        output_root=test_ops['save_path0'],
+        outputs_to_check=['F', 'Fneu', 'stat', 'spks'],
+        test_data_dir= test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes=nplanes
     ))
 
 
@@ -133,8 +133,8 @@ def test_extraction_output_2plane2chan(test_ops):
     extract_wrapper(ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        ['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks'],
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes
+        output_root=test_ops['save_path0'],
+        outputs_to_check=['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks'],
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes=nplanes
     ))

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -104,12 +104,12 @@ def test_extraction_output_1plane1chan(test_ops):
         (404, 360)
     )
     extract_wrapper(ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         ['F', 'Fneu', 'stat', 'spks'],
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes
     ))
 
 
@@ -131,10 +131,10 @@ def test_extraction_output_2plane2chan(test_ops):
     ops[0]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p0.npy'))
     ops[1]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p1.npy'))
     extract_wrapper(ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         ['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks'],
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes
     ))

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -65,9 +65,9 @@ def test_2plane_2chan_with_batches(test_ops):
         nplanes = ops['nplanes']
         suite2p.run_s2p(ops=ops)
         assert all(utils.check_output(
-            output_root=test_ops['save_path0'],
-            outputs_to_check=get_outputs_to_check(test_ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
-            test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+            output_root=ops['save_path0'],
+            outputs_to_check=get_outputs_to_check(ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
+            test_data_dir=ops['data_path'][0].joinpath(f"{nplanes}plane{ops['nchannels']}chan1500/suite2p/"),
             nplanes=nplanes,
         ))
 

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -28,23 +28,21 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     })
     suite2p.run_s2p(ops=test_ops)
 
-    outputs_to_check = ['F', 'Fneu', 'spks', 'iscell']
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         output_root=test_ops['save_path0'],
-        outputs_to_check=outputs_to_check,
+        outputs_to_check=get_outputs_to_check(test_ops['nchannels']),
         test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
         nplanes=nplanes,
     ))
-
     # Read Nwb data and make sure it's identical to output data
     stat, ops, F, Fneu, spks, iscell, probcell, redcell, probredcell = \
         io.read_nwb(str(Path(test_ops['save_path0']).joinpath('suite2p/ophys.nwb')))
     assert all(utils.compare_list_of_outputs(
         0,
-        outputs_to_check,
-        utils.get_list_of_output_data(outputs_to_check, test_ops['save_path0'], 0),
-        [F, Fneu, spks, np.stack([iscell.astype(np.float32), probcell.astype(np.float32)]).T],
+        get_outputs_to_check(test_ops['nchannels']),
+        utils.get_list_of_output_data(get_outputs_to_check(test_ops['nchannels']), test_ops['save_path0'], 0),
+        [F, Fneu, np.stack([iscell.astype(np.float32), probcell.astype(np.float32)]).T, spks, stat],
     ))
 
 

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -29,13 +29,12 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     suite2p.run_s2p(ops=test_ops)
 
     outputs_to_check = ['F', 'Fneu', 'spks', 'iscell']
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         outputs_to_check,
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
-        added_tag='1500'
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+        nplanes,
     ))
 
     # Read Nwb data and make sure it's identical to output data
@@ -63,14 +62,13 @@ def test_2plane_2chan_with_batches(test_ops):
             'reg_tif': True,
             'reg_tif_chan2': True,
         })
+        nplanes = test_ops['nplanes']
         suite2p.run_s2p(ops=ops)
         assert all(utils.check_output(
             ops['save_path0'],
             get_outputs_to_check(ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
-            ops['data_path'][0],
-            ops['nplanes'],
-            ops['nchannels'],
-            added_tag='1500'
+            test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+            nplanes,
         ))
 
 
@@ -87,10 +85,10 @@ def test_1plane_2chan_sourcery(test_ops):
         'keep_movie_raw': True
     })
     suite2p.run_s2p(ops=test_ops)
+    nplanes = test_ops['nplanes']
     assert all(utils.check_output(
         test_ops['save_path0'],
         get_outputs_to_check(test_ops['nchannels']),
-        test_ops['data_path'][0],
-        test_ops['nplanes'],
-        test_ops['nchannels'],
+        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes,
     ))

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -31,10 +31,10 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     outputs_to_check = ['F', 'Fneu', 'spks', 'iscell']
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        outputs_to_check,
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
-        nplanes,
+        output_root=test_ops['save_path0'],
+        outputs_to_check=outputs_to_check,
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+        nplanes=nplanes,
     ))
 
     # Read Nwb data and make sure it's identical to output data
@@ -62,16 +62,14 @@ def test_2plane_2chan_with_batches(test_ops):
             'reg_tif': True,
             'reg_tif_chan2': True,
         })
-        nplanes = test_ops['nplanes']
+        nplanes = ops['nplanes']
         suite2p.run_s2p(ops=ops)
         assert all(utils.check_output(
-            ops['save_path0'],
-            get_outputs_to_check(ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
-            test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
-            nplanes,
+            output_root=test_ops['save_path0'],
+            outputs_to_check=get_outputs_to_check(test_ops['nchannels']) + ['reg_tif', 'reg_tif_chan2'],
+            test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
+            nplanes=nplanes,
         ))
-
-
 
 
 def test_1plane_2chan_sourcery(test_ops):
@@ -87,8 +85,8 @@ def test_1plane_2chan_sourcery(test_ops):
     suite2p.run_s2p(ops=test_ops)
     nplanes = test_ops['nplanes']
     assert all(utils.check_output(
-        test_ops['save_path0'],
-        get_outputs_to_check(test_ops['nchannels']),
-        test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes,
+        output_root=test_ops['save_path0'],
+        outputs_to_check=get_outputs_to_check(test_ops['nchannels']),
+        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
+        nplanes=nplanes,
     ))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,13 +41,12 @@ def check_dict_dicts_all_close(first_dict, second_dict) -> Iterator[bool]:
             yield np.allclose(gt_dict[k], output_dict[k], rtol=r_tol, atol=a_tol)
 
 
-def get_list_of_test_data(outputs_to_check, test_data_dir, nplanes, nchannels, added_tag, curr_plane):
+def get_list_of_test_data(outputs_to_check, test_plane_dir):
     """
     Gets list of test_data from test data directory matching provided nplanes, nchannels, and added_tag. Returns
     all test_data for given plane number.
     """
     test_data_list = []
-    test_plane_dir = test_data_dir.joinpath(f'{nplanes}plane{nchannels}chan{added_tag}/suite2p/plane{curr_plane}')
     for output in outputs_to_check:
         if 'reg_tif' in output:
             filename = np.concatenate([imread(tif) for tif in glob(str(test_plane_dir.joinpath(f"{output}/*.tif")))])
@@ -78,10 +77,11 @@ def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int, nch
     as the ground truth outputs.
     """
     for i in range(nplanes):
+        test_plane_dir = test_data_dir.joinpath(f'{nplanes}plane{nchannels}chan{added_tag}/suite2p/plane{i}')
         yield all(compare_list_of_outputs(
             i,
             outputs_to_check,
-            get_list_of_test_data(outputs_to_check, test_data_dir, nplanes, nchannels, added_tag, i),
+            get_list_of_test_data(outputs_to_check, test_plane_dir),
             get_list_of_output_data(outputs_to_check, output_root, i),
         ))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,13 +71,13 @@ def get_list_of_output_data(outputs_to_check, output_root, curr_plane):
     return output_data_list
 
 
-def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int, nchannels: int, added_tag="") -> Iterator[bool]:
+def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int) -> Iterator[bool]:
     """
     Helper function to check if outputs given by a test are exactly the same
     as the ground truth outputs.
     """
     for i in range(nplanes):
-        test_plane_dir = test_data_dir.joinpath(f'{nplanes}plane{nchannels}chan{added_tag}/suite2p/plane{i}')
+        test_plane_dir = test_data_dir.joinpath(f'plane{i}')
         yield all(compare_list_of_outputs(
             i,
             outputs_to_check,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,4 +91,7 @@ def compare_list_of_outputs(plane_num, output_name_list, data_list_one, data_lis
         if output == 'stat':  # where the elements of npy arrays are dictionaries (e.g: stat.npy)
             yield check_dict_dicts_all_close(data1, data2)
         else:
+            if output == 'iscell':  # just check the first column; are cells/noncells classified the same way?
+                data1 = data1[:, 0]
+                data2 = data2[:, 0]
             yield np.allclose(data1, data2, rtol=r_tol, atol=a_tol)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ from tifffile import imread
 import numpy as np
 from glob import glob
 
-r_tol, a_tol = 1e-4, 5e-2
+r_tol, a_tol = 5e-3, 9e-1  # Matters for F, Fneu, spks, and stat
 
 
 def get_plane_dir(op, plane, mkdir=True):
@@ -90,8 +90,9 @@ def compare_list_of_outputs(plane_num, output_name_list, data_list_one, data_lis
     for output, data1, data2 in zip(output_name_list, data_list_one, data_list_two):
         if output == 'stat':  # where the elements of npy arrays are dictionaries (e.g: stat.npy)
             yield check_dict_dicts_all_close(data1, data2)
+        elif output == 'iscell':  # just check the first column; are cells/noncells classified the same way?
+            data1 = data1[:, 0]
+            data2 = data2[:, 0]
+            yield np.array_equal(data1, data2)
         else:
-            if output == 'iscell':  # just check the first column; are cells/noncells classified the same way?
-                data1 = data1[:, 0]
-                data2 = data2[:, 0]
             yield np.allclose(data1, data2, rtol=r_tol, atol=a_tol)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ from tifffile import imread
 import numpy as np
 from glob import glob
 
-r_tol, a_tol = 5e-3, 9e-1  # Matters for F, Fneu, spks, and stat
+r_tol, a_tol = 1e-4, 5e-2
 
 
 def get_plane_dir(op, plane, mkdir=True):


### PR DESCRIPTION
One part of #511. 

1. test/utils.py was refactored to work with checking the outputs of test data that aren't in {}plane{}chan format. 
2. Added back classify.py with the classify func as requested [here](https://github.com/MouseLand/suite2p).
3. Just check the cell/non-cell results in our tests (not probabilities).