### PR TITLE
Test utils refactor

### DIFF
--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -27,6 +27,11 @@ class BinaryFile:
         self._index = 0
         self._can_read = True
 
+    @staticmethod
+    def convert_numpy_file_to_suite2p_binary(from_filename, to_filename):
+        """Works with npz files, pickled npy files, etc."""
+        np.load(from_filename).tofile(to_filename)
+
     @property
     def nbytesread(self):
         """number of bytes per frame (FIXED for given file)"""

--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -102,6 +102,10 @@ class BinaryFile:
         self.read_file.seek(orig_ptr)
         return frames
 
+    @property
+    def data(self):
+        return np.fromfile(self.read_file, np.int16).reshape(-1, self.Ly, self.Lx)
+
     def read(self, batch_size=1, dtype=np.float32) -> Optional[Tuple[np.ndarray, np.ndarray]]:
         if not self._can_read:
             raise IOError("BinaryFile needs to write before it can read again.")

--- a/suite2p/io/binary.py
+++ b/suite2p/io/binary.py
@@ -104,7 +104,10 @@ class BinaryFile:
 
     @property
     def data(self):
-        return np.fromfile(self.read_file, np.int16).reshape(-1, self.Ly, self.Lx)
+        orig_ptr = self.read_file.tell()
+        mov = np.fromfile(self.read_file, np.int16).reshape(-1, self.Ly, self.Lx)
+        self.read_file.seek(orig_ptr)
+        return mov
 
     def read(self, batch_size=1, dtype=np.float32) -> Optional[Tuple[np.ndarray, np.ndarray]]:
         if not self._can_read:

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -25,7 +25,7 @@ def prepare_for_detection(op, input_file_name_list, dimensions):
     ops = []
     for plane in range(op['nplanes']):
         curr_op = op.copy()
-        plane_dir = utils.get_plane_dir(op, plane)
+        plane_dir = utils.get_plane_dir(save_path0=op['save_path0'], plane=plane)
         bin_path = utils.write_data_to_binary(
             str(plane_dir.joinpath('data.bin')), str(input_file_name_list[plane][0])
         )

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -26,9 +26,8 @@ def prepare_for_detection(op, input_file_name_list, dimensions):
     for plane in range(op['nplanes']):
         curr_op = op.copy()
         plane_dir = utils.get_plane_dir(save_path0=op['save_path0'], plane=plane)
-        bin_path = utils.write_data_to_binary(
-            str(plane_dir.joinpath('data.bin')), str(input_file_name_list[plane][0])
-        )
+        bin_path = str(plane_dir.joinpath('data.bin'))
+        utils.convert_npz_to_suite2p_binary(bin_path, str(input_file_name_list[plane][0]))
         curr_op['meanImg'] = np.reshape(
             np.load(str(input_file_name_list[plane][0])), (-1, op['Ly'], op['Lx'])
         ).mean(axis=0)
@@ -36,9 +35,8 @@ def prepare_for_detection(op, input_file_name_list, dimensions):
         if plane == 1: # Second plane result has different crop.
             curr_op['xrange'], curr_op['yrange'] = [[1, 403], [1, 359]]
         if curr_op['nchannels'] == 2:
-            bin2_path = utils.write_data_to_binary(
-                str(plane_dir.joinpath('data_chan2.bin')), str(input_file_name_list[plane][1])
-            )
+            bin2_path = str(plane_dir.joinpath('data_chan2.bin'))
+            utils.convert_npz_to_suite2p_binary(bin2_path, str(input_file_name_list[plane][1]))
             curr_op['reg_file_chan2'] = bin2_path
         curr_op['save_path'] = plane_dir
         curr_op['ops_path'] = plane_dir.joinpath('ops.npy')

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -6,6 +6,7 @@ import numpy as np
 import utils
 from suite2p import detection
 from suite2p.classification import builtin_classfile
+from suite2p.io import BinaryFile
 
 
 def prepare_for_detection(op, input_file_name_list, dimensions):
@@ -27,16 +28,17 @@ def prepare_for_detection(op, input_file_name_list, dimensions):
         curr_op = op.copy()
         plane_dir = utils.get_plane_dir(save_path0=op['save_path0'], plane=plane)
         bin_path = str(plane_dir.joinpath('data.bin'))
-        utils.convert_npz_to_suite2p_binary(bin_path, str(input_file_name_list[plane][0]))
+        BinaryFile.convert_numpy_file_to_suite2p_binary(str(input_file_name_list[plane][0]), bin_path)
         curr_op['meanImg'] = np.reshape(
             np.load(str(input_file_name_list[plane][0])), (-1, op['Ly'], op['Lx'])
         ).mean(axis=0)
         curr_op['reg_file'] = bin_path
         if plane == 1: # Second plane result has different crop.
-            curr_op['xrange'], curr_op['yrange'] = [[1, 403], [1, 359]]
+            curr_op['xrange'] = [1, 403]
+            curr_op['yrange'] = [1, 359]
         if curr_op['nchannels'] == 2:
             bin2_path = str(plane_dir.joinpath('data_chan2.bin'))
-            utils.convert_npz_to_suite2p_binary(bin2_path, str(input_file_name_list[plane][1]))
+            BinaryFile.convert_numpy_file_to_suite2p_binary(str(input_file_name_list[plane][1]), bin2_path)
             curr_op['reg_file_chan2'] = bin2_path
         curr_op['save_path'] = plane_dir
         curr_op['ops_path'] = plane_dir.joinpath('ops.npy')

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -25,9 +25,8 @@ def prepare_for_extraction(op, input_file_name_list, dimensions):
     for plane in range(op['nplanes']):
         curr_op = op.copy()
         plane_dir = utils.get_plane_dir(save_path0=op['save_path0'], plane=plane)
-        bin_path = utils.write_data_to_binary(
-            str(plane_dir.joinpath('data.bin')), str(input_file_name_list[plane][0])
-        )
+        bin_path = str(plane_dir.joinpath('data.bin'))
+        utils.convert_npz_to_suite2p_binary(bin_path, str(input_file_name_list[plane][0]))
         curr_op['meanImg'] = np.reshape(
             np.load(str(input_file_name_list[plane][0])), (-1, op['Ly'], op['Lx'])
         ).mean(axis=0)
@@ -35,9 +34,8 @@ def prepare_for_extraction(op, input_file_name_list, dimensions):
         if plane == 1: # Second plane result has different crop.
             curr_op['xrange'], curr_op['yrange'] = [[1, 403], [1, 359]]
         if curr_op['nchannels'] == 2:
-            bin2_path = utils.write_data_to_binary(
-                str(plane_dir.joinpath('data_chan2.bin')), str(input_file_name_list[plane][1])
-            )
+            bin2_path = str(plane_dir.joinpath('data_chan2.bin'))
+            utils.convert_npz_to_suite2p_binary(bin2_path, str(input_file_name_list[plane][1]))
             curr_op['reg_file_chan2'] = bin2_path
         curr_op['save_path'] = plane_dir
         curr_op['ops_path'] = plane_dir.joinpath('ops.npy')

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -3,6 +3,8 @@ Tests for the Suite2p Extraction module.
 """
 import numpy as np
 from suite2p import extraction
+from suite2p.io import BinaryFile
+
 from pathlib import Path
 import utils
 
@@ -26,7 +28,7 @@ def prepare_for_extraction(op, input_file_name_list, dimensions):
         curr_op = op.copy()
         plane_dir = utils.get_plane_dir(save_path0=op['save_path0'], plane=plane)
         bin_path = str(plane_dir.joinpath('data.bin'))
-        utils.convert_npz_to_suite2p_binary(bin_path, str(input_file_name_list[plane][0]))
+        BinaryFile.convert_numpy_file_to_suite2p_binary(str(input_file_name_list[plane][0]), bin_path)
         curr_op['meanImg'] = np.reshape(
             np.load(str(input_file_name_list[plane][0])), (-1, op['Ly'], op['Lx'])
         ).mean(axis=0)
@@ -35,7 +37,7 @@ def prepare_for_extraction(op, input_file_name_list, dimensions):
             curr_op['xrange'], curr_op['yrange'] = [[1, 403], [1, 359]]
         if curr_op['nchannels'] == 2:
             bin2_path = str(plane_dir.joinpath('data_chan2.bin'))
-            utils.convert_npz_to_suite2p_binary(bin2_path, str(input_file_name_list[plane][1]))
+            BinaryFile.convert_numpy_file_to_suite2p_binary(str(input_file_name_list[plane][1]), bin2_path)
             curr_op['reg_file_chan2'] = bin2_path
         curr_op['save_path'] = plane_dir
         curr_op['ops_path'] = plane_dir.joinpath('ops.npy')

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -24,7 +24,7 @@ def prepare_for_extraction(op, input_file_name_list, dimensions):
     ops = []
     for plane in range(op['nplanes']):
         curr_op = op.copy()
-        plane_dir = utils.get_plane_dir(op, plane)
+        plane_dir = utils.get_plane_dir(save_path0=op['save_path0'], plane=plane)
         bin_path = utils.write_data_to_binary(
             str(plane_dir.joinpath('data.bin')), str(input_file_name_list[plane][0])
         )
@@ -48,7 +48,7 @@ def prepare_for_extraction(op, input_file_name_list, dimensions):
 def extract_wrapper(ops):
     for plane in range(ops[0]['nplanes']):
         curr_op = ops[plane]
-        plane_dir = utils.get_plane_dir(curr_op, plane)
+        plane_dir = utils.get_plane_dir(save_path0=curr_op['save_path0'], plane=plane)
         extract_input = np.load(
             curr_op['data_path'][0].joinpath(
                 'detection',

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -38,7 +38,6 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     stat, ops, F, Fneu, spks, iscell, probcell, redcell, probredcell = \
         io.read_nwb(str(Path(test_ops['save_path0']).joinpath('suite2p/ophys.nwb')))
     assert all(utils.compare_list_of_outputs(
-        0,
         get_outputs_to_check(test_ops['nchannels']),
         utils.get_list_of_output_data(get_outputs_to_check(test_ops['nchannels']), test_ops['save_path0'], 0),
         [F, Fneu, np.stack([iscell.astype(np.float32), probcell.astype(np.float32)]).T, spks, stat],

--- a/tests/regression/test_io_pipeline.py
+++ b/tests/regression/test_io_pipeline.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from tifffile import imread
 from suite2p import io
 
-from utils import get_binary_file_data
-
 
 def test_tiff_reconstruction_from_binary_file(test_ops):
     """
@@ -14,7 +12,7 @@ def test_tiff_reconstruction_from_binary_file(test_ops):
     """
     test_ops['tiff_list'] = ['input.tif']
     op = io.tiff_to_binary(test_ops)
-    output_data = get_binary_file_data(op)
+    output_data = io.BinaryFile(read_filename=Path(op['save_path0'], 'suite2p/plane0/data.bin'), Ly=op['Ly'], Lx=op['Lx']).data
     # Make sure data in matrix is nonnegative
     assert np.all(output_data >= 0)
     fname = io.generate_tiff_filename(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -27,10 +27,6 @@ def test_h5_to_binary_produces_nonnegative_output_data(test_ops):
     assert np.all(output_data >= 0)
 
 
-def test_that_BinaryFile_class_counts_frames_correctly(binfile1500):
-    assert binfile1500.n_frames == 1500
-
-
 def test_that_bin_movie_without_badframes_results_in_a_same_size_array(binfile1500):
     Ly, Lx = binfile1500.Ly, binfile1500.Lx
     mov = binfile1500.bin_movie(bin_size=1)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,15 +1,12 @@
 """
 Tests for the Suite2p IO module
 """
+from pathlib import Path
 
 import numpy as np
-from pathlib import Path
-from suite2p import io
 from pytest import fixture
 
-from utils import get_binary_file_data
-
-
+from suite2p import io
 
 
 @fixture()
@@ -26,7 +23,7 @@ def test_h5_to_binary_produces_nonnegative_output_data(test_ops):
     test_ops['h5py'] = Path(test_ops['data_path'][0]).joinpath('input.h5')
     test_ops['data_path'] = []
     op = io.h5py_to_binary(test_ops)
-    output_data = get_binary_file_data(op)
+    output_data = io.BinaryFile(read_filename=Path(op['save_path0'], 'suite2p/plane0/data.bin'), Ly=op['Ly'], Lx=op['Lx']).data
     assert np.all(output_data >= 0)
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -40,3 +40,14 @@ def test_that_bin_movie_with_badframes_results_in_a_smaller_array(binfile1500):
 
     assert len(mov) < binfile1500.n_frames, "bin_movie didn't produce a smaller array."
     assert len(mov) == len(bad_frames) - sum(bad_frames), "bin_movie didn't produce the right size array."
+
+
+
+def test_that_binaryfile_data_is_repeatable(binfile1500):
+    data1 = binfile1500.data
+    assert data1.shape == (1500, binfile1500.Ly, binfile1500.Lx)
+
+    data2 = binfile1500.data
+    assert data2.shape == (1500, binfile1500.Ly, binfile1500.Lx)
+
+    assert np.allclose(data1, data2)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -28,7 +28,8 @@ def test_h5_to_binary_produces_nonnegative_output_data(test_ops):
 
 
 def test_that_bin_movie_without_badframes_results_in_a_same_size_array(binfile1500):
-    assert binfile1500.bin_movie(bin_size=1).shape == (1500, binfile1500.Ly, binfile1500.Lx)
+    mov = binfile1500.bin_movie(bin_size=1)
+    assert mov.shape == (1500, binfile1500.Ly, binfile1500.Lx)
 
 
 def test_that_bin_movie_with_badframes_results_in_a_smaller_array(binfile1500):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -28,9 +28,7 @@ def test_h5_to_binary_produces_nonnegative_output_data(test_ops):
 
 
 def test_that_bin_movie_without_badframes_results_in_a_same_size_array(binfile1500):
-    Ly, Lx = binfile1500.Ly, binfile1500.Lx
-    mov = binfile1500.bin_movie(bin_size=1)
-    assert mov.shape == (1500, Ly, Lx)
+    assert binfile1500.bin_movie(bin_size=1).shape == (1500, binfile1500.Ly, binfile1500.Lx)
 
 
 def test_that_bin_movie_with_badframes_results_in_a_smaller_array(binfile1500):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,8 +7,6 @@ from tifffile import imread
 import numpy as np
 from glob import glob
 
-from suite2p.io import BinaryFile
-
 r_tol, a_tol = 1e-4, 5e-2
 
 
@@ -16,10 +14,6 @@ def get_plane_dir(save_path0: str, plane: int) -> Path:
     plane_dir = Path(save_path0).joinpath(f'suite2p/plane{plane}')
     plane_dir.mkdir(exist_ok=True, parents=True)
     return plane_dir
-
-
-def get_binary_file_data(op) -> np.ndarray:
-    return BinaryFile(read_filename=Path(op['save_path0'], 'suite2p/plane0/data.bin'), Ly=op['Ly'], Lx=op['Lx']).data
 
 
 def write_data_to_binary(binary_path, data_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,11 +16,8 @@ def get_plane_dir(save_path0: str, plane: int) -> Path:
     return plane_dir
 
 
-def write_data_to_binary(binary_path, data_path):
-    input_data = np.load(data_path)
-    with open(binary_path, 'wb') as f:
-        input_data.tofile(f)
-    return binary_path
+def convert_npz_to_suite2p_binary(binary_path, data_path):
+    np.load(data_path).tofile(binary_path)
 
 
 def check_lists_of_arr_all_close(list1, list2) -> Iterator[bool]:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,14 +10,13 @@ from glob import glob
 r_tol, a_tol = 1e-4, 5e-2
 
 
-def get_plane_dir(op, plane, mkdir=True):
-    plane_dir = Path(op['save_path0']).joinpath('suite2p/plane{}'.format(plane))
-    if mkdir:
-        plane_dir.mkdir(exist_ok=True, parents=True)
+def get_plane_dir(save_path0: str, plane: int) -> Path:
+    plane_dir = Path(save_path0).joinpath(f'suite2p/plane{plane}')
+    plane_dir.mkdir(exist_ok=True, parents=True)
     return plane_dir
 
 
-def get_binary_file_data(op):
+def get_binary_file_data(op) -> np.ndarray:
     # Read in binary file's contents as int16 np array
     mov = np.fromfile(str(Path(op['save_path0']).joinpath('suite2p/plane0/data.bin')), np.int16)
     return mov.reshape(-1, op['Ly'], op['Lx'])
@@ -46,27 +45,29 @@ def get_list_of_test_data(outputs_to_check, test_plane_dir):
     Gets list of test_data from test data directory matching provided nplanes, nchannels, and added_tag. Returns
     all test_data for given plane number.
     """
-    test_data_list = []
+    test_data = []
     for output in outputs_to_check:
+        data_path = test_plane_dir.joinpath(f"{output}")
         if 'reg_tif' in output:
-            filename = np.concatenate([imread(tif) for tif in glob(str(test_plane_dir.joinpath(f"{output}/*.tif")))])
+            data = np.concatenate([imread(tif) for tif in glob(str(data_path.joinpath("*.tif")))])
         else:
-            filename = np.load(str(test_plane_dir.joinpath(f"{output}.npy")), allow_pickle=True)
-        test_data_list.append(filename)
-    return test_data_list
+            data = np.load(str(data_path) + ".npy", allow_pickle=True)
+        test_data.append(data)
+    return test_data
 
 
 def get_list_of_output_data(outputs_to_check, output_root, curr_plane):
     """
     Gets list of output data from output_directory. Returns all data for given plane number.
     """
-    output_dir = Path(output_root).joinpath("suite2p", 'plane{}'.format(curr_plane))
+    output_dir = Path(output_root).joinpath(f"suite2p/plane{curr_plane}")
     output_data_list = []
     for output in outputs_to_check:
+        data_path = output_dir.joinpath(f"{output}")
         if 'reg_tif' in output:
-            filename = np.concatenate([imread(tif) for tif in glob(str(output_dir.joinpath(f"{output}/*.tif")))])
+            filename = np.concatenate([imread(tif) for tif in glob(str(data_path.joinpath("*.tif")))])
         else:
-            filename = np.load(str(output_dir.joinpath(f"{output}.npy")), allow_pickle=True)
+            filename = np.load(str(data_path) + ".npy", allow_pickle=True)
         output_data_list.append(filename)
     return output_data_list
 
@@ -77,22 +78,18 @@ def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int) -> 
     as the ground truth outputs.
     """
     for i in range(nplanes):
-        test_plane_dir = test_data_dir.joinpath(f'plane{i}')
         yield all(compare_list_of_outputs(
-            i,
             outputs_to_check,
-            get_list_of_test_data(outputs_to_check, test_plane_dir),
+            get_list_of_test_data(outputs_to_check, test_data_dir.joinpath(f'plane{i}')),
             get_list_of_output_data(outputs_to_check, output_root, i),
         ))
 
 
-def compare_list_of_outputs(plane_num, output_name_list, data_list_one, data_list_two) -> Iterator[bool]:
+def compare_list_of_outputs(output_name_list, data_list_one, data_list_two) -> Iterator[bool]:
     for output, data1, data2 in zip(output_name_list, data_list_one, data_list_two):
         if output == 'stat':  # where the elements of npy arrays are dictionaries (e.g: stat.npy)
             yield check_dict_dicts_all_close(data1, data2)
         elif output == 'iscell':  # just check the first column; are cells/noncells classified the same way?
-            data1 = data1[:, 0]
-            data2 = data2[:, 0]
-            yield np.array_equal(data1, data2)
+            yield np.array_equal(data1[:, 0], data2[:, 0])
         else:
             yield np.allclose(data1, data2, rtol=r_tol, atol=a_tol)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,10 +16,6 @@ def get_plane_dir(save_path0: str, plane: int) -> Path:
     return plane_dir
 
 
-def convert_npz_to_suite2p_binary(binary_path, data_path):
-    np.load(data_path).tofile(binary_path)
-
-
 def check_lists_of_arr_all_close(list1, list2) -> Iterator[bool]:
     for l1, l2 in zip(list1, list2):
         yield np.allclose(l1, l2, rtol=r_tol, atol=a_tol)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,8 @@ from tifffile import imread
 import numpy as np
 from glob import glob
 
+from suite2p.io import BinaryFile
+
 r_tol, a_tol = 1e-4, 5e-2
 
 
@@ -17,9 +19,7 @@ def get_plane_dir(save_path0: str, plane: int) -> Path:
 
 
 def get_binary_file_data(op) -> np.ndarray:
-    # Read in binary file's contents as int16 np array
-    mov = np.fromfile(str(Path(op['save_path0']).joinpath('suite2p/plane0/data.bin')), np.int16)
-    return mov.reshape(-1, op['Ly'], op['Lx'])
+    return BinaryFile(read_filename=Path(op['save_path0'], 'suite2p/plane0/data.bin'), Ly=op['Ly'], Lx=op['Lx']).data
 
 
 def write_data_to_binary(binary_path, data_path):


### PR DESCRIPTION
This pull request mainly simplifies some of the utility functions in the regression testing framework.  As part of this simplification, some useful file handling code and assumptions about underlying file format that was in the utils were moved to io.BinaryFile:

  - BinaryFile.data: a property that returns a 3D numpy array.   Can be called repeatedly without affecting the order of read() operations.

   - BinaryFile.convert_numpy_to_suite2p_binary(): a function that loads a numpy array from disk and then saves it as a binary file.  It's done throughout the testing, but doesn't call any of BinaryFile's code, which can lead to issues if the file format ever changes.  Putting it with the BinaryFile class makes these assumptions clear and simple to debug in the future without needing to modify tests.

