### PR TITLE
ops['date_proc'] becomes string (not empty list) when saving to mat f…

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -129,22 +129,20 @@ This will include all of the options you ran the pipeline with,
 including file paths. During the running of the pipeline, some outputs
 are added to ``ops.npy``:
 
--  reg_file: location of registered binary file
--  Ly: size of Y dimension of tiffs/h5
--  Lx: size of X dimension of tiffs/h5
--  nframes: number of frames in recording
--  yrange: valid y-range used for cell detection (excludes edges that
-   were shifted out of the FOV during registration)
--  xrange: valid x-range used for cell detection (excludes edges that
-   were shifted out of the FOV during registration)
--  refImg: reference image used for registration
--  yoff: y-shifts of recording at each timepoint
--  xoff: x-shifts of recording at each timepoint
--  corrXY: peak of phase correlation between frame and reference image
-   at each timepoint
--  meanImg: mean of registered frames
--  meanImgE: a median-filtered version of the mean image
--  Vcorr: correlation map (computed during cell detection)
--  filelist: List of the image file names (e.g. tiff) that were loaded, in the order that Suite2p processed them.
+    -  **reg_file**: location of registered binary file
+    -  **Ly**: size of Y dimension of tiffs/h5
+    -  **Lx**: size of X dimension of tiffs/h5
+    -  **nframes**: number of frames in recording
+    -  **yrange**: valid y-range used for cell detection (excludes edges that were shifted out of the FOV during registration)
+    -  **xrange**: valid x-range used for cell detection (excludes edges that were shifted out of the FOV during registration)
+    -  **refImg**: reference image used for registration
+    -  **yoff**: y-shifts of recording at each timepoint
+    -  **xoff**: x-shifts of recording at each timepoint
+    -  **corrXY**: peak of phase correlation between frame and reference image at each timepoint
+    -  **meanImg**: mean of registered frames
+    -  **meanImgE**: a median-filtered version of the mean image
+    -  **Vcorr**: correlation map (computed during cell detection)
+    -  **filelist**: List of the image file names (e.g. tiff) that were loaded, in the order that Suite2p processed them.
+    -  **date_proc**: Date and time that the analysis was run.
 
 .. _npy-matlab: https://github.com/kwikteam/npy-matlab

--- a/suite2p/run_s2p.py
+++ b/suite2p/run_s2p.py
@@ -1,9 +1,8 @@
-import datetime
 import os
 import shutil
 import time
 from natsort import natsorted
-from itertools import chain
+from datetime import datetime
 
 import numpy as np
 from scipy.io import savemat
@@ -140,7 +139,7 @@ def run_plane(ops, ops_path=None):
     t1 = time.time()
     
     ops = {**default_ops(), **ops}
-    ops['date_proc'] = datetime.datetime.now()
+    ops['date_proc'] = datetime.now()
     plane_times = {}
     if ops_path is not None:
         ops['save_path'] = os.path.split(ops_path)[0]
@@ -265,8 +264,8 @@ def run_plane(ops, ops_path=None):
 
         # save as matlab file
         if ops.get('save_mat'):
-            if 'date_proc' in ops:
-                ops['date_proc'] = []
+            if isinstance(ops.get('date_proc'), datetime):
+                ops['date_proc'] = datetime.strftime(ops['date_proc'], "%Y-%m-%d %H:%M:%S.%f"),
             savemat(
                 file_name=os.path.join(ops['save_path'], 'Fall.mat'),
                 mdict={


### PR DESCRIPTION
Closes #523 .

Saves the datetime as a string (not an empty list) to the mat file, and adds a description of the date_proc attribute to the docs.

Best wishes,

Nick