### PR TITLE
bugfix: ufunc cast error when loading bruker files

### DIFF
--- a/data/test_data.dvc
+++ b/data/test_data.dvc
@@ -1,3 +1,3 @@
 outs:
-- md5: 273c132e8b2d31901a45c70188e68535.dir
+- md5: eaa434ed20e421fccab8089842be58b5.dir
   path: test_data

--- a/suite2p/io/tiff.py
+++ b/suite2p/io/tiff.py
@@ -412,6 +412,8 @@ def ome_to_binary(ops):
     # loop over all tiffs
     with ScanImageTiffReader(fs_Ch1[0]) as tif:
         im0 = tif.data()
+    if im0.dtype.type == np.uint16:
+        im0 = (im0 // 2).astype(np.int16)
 
     for ops1_0 in ops1:
         ops1_0['nframes'] = 0
@@ -459,9 +461,9 @@ def ome_to_binary(ops):
         if not do_registration:
             ops['yrange'] = np.array([0,ops['Ly']])
             ops['xrange'] = np.array([0,ops['Lx']])
-        ops['meanImg'] /= ops['nframes']
+        ops['meanImg'] //= ops['nframes']
         if nchannels>1:
-            ops['meanImg_chan2'] /= ops['nframes']
+            ops['meanImg_chan2'] //= ops['nframes']
         np.save(ops['ops_path'], ops)
     # close all binary files and write ops files
     for j in range(0,nplanes):

--- a/tests/smoke/test_file_loading.py
+++ b/tests/smoke/test_file_loading.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import suite2p
+
+
+def test_bruker(test_ops):
+    test_ops['data_path'] = [Path(test_ops['data_path'][0]).joinpath('bruker')]
+    test_ops['input_format'] = 'bruker'
+    print(test_ops['nchannels'])
+    suite2p.run_s2p(ops=test_ops)


### PR DESCRIPTION
Closes #545 , adds test coverage to `io.tiff.ome_to_binary()`