### PR TITLE
Increase Test transparency

### DIFF
--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -92,9 +92,11 @@ def test_detection_output_2plane2chan(test_ops):
     ops[1]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p1.npy'))
     detect_wrapper(ops)
     nplanes = test_ops['nplanes']
-    assert all(utils.check_output(
-        output_root=test_ops['save_path0'],
-        outputs_to_check=['redcell'],
-        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes=nplanes
-    ))
+
+    outputs_to_check = ['redcell']
+    for i in range(nplanes):
+        assert all(utils.compare_list_of_outputs(
+            outputs_to_check,
+            utils.get_list_of_data(outputs_to_check, test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/plane{i}")),
+            utils.get_list_of_data(outputs_to_check, Path(test_ops['save_path0']).joinpath(f"suite2p/plane{i}")),
+        ))

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -1,7 +1,7 @@
 """
 Tests for the Suite2p Detection module.
 """
-
+from pathlib import Path
 import numpy as np
 import utils
 from suite2p import detection
@@ -26,7 +26,8 @@ def prepare_for_detection(op, input_file_name_list, dimensions):
     ops = []
     for plane in range(op['nplanes']):
         curr_op = op.copy()
-        plane_dir = utils.get_plane_dir(save_path0=op['save_path0'], plane=plane)
+        plane_dir = Path(op['save_path0']).joinpath(f'suite2p/plane{plane}')
+        plane_dir.mkdir(exist_ok=True, parents=True)
         bin_path = str(plane_dir.joinpath('data.bin'))
         BinaryFile.convert_numpy_file_to_suite2p_binary(str(input_file_name_list[plane][0]), bin_path)
         curr_op['meanImg'] = np.reshape(

--- a/tests/regression/test_detection_pipeline.py
+++ b/tests/regression/test_detection_pipeline.py
@@ -62,7 +62,9 @@ def detect_wrapper(ops):
         assert np.array_equal(output_check['cell_pix'], cell_pix)
         assert all(np.allclose(a, b, rtol=1e-4, atol=5e-2) for a, b in zip(cell_masks, output_check['cell_masks']))
         assert all(np.allclose(a, b, rtol=1e-4, atol=5e-2) for a, b in zip(neuropil_masks, output_check['neuropil_masks']))
-        assert all(utils.check_dict_dicts_all_close(stat, output_check['stat']))
+        for gt_dict, output_dict in zip(stat, output_check['stat']):
+            for k in gt_dict.keys():
+                assert np.allclose(gt_dict[k], output_dict[k], rtol=1e-4, atol=5e-2)
 
 
 def test_detection_output_1plane1chan(test_ops):

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -107,12 +107,13 @@ def test_extraction_output_1plane1chan(test_ops):
     )
     extract_wrapper(ops)
     nplanes = test_ops['nplanes']
-    assert all(utils.check_output(
-        output_root=test_ops['save_path0'],
-        outputs_to_check=['F', 'Fneu', 'stat', 'spks'],
-        test_data_dir= test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes=nplanes
-    ))
+    outputs_to_check = ['F', 'Fneu', 'stat', 'spks']
+    for i in range(nplanes):
+        assert all(utils.compare_list_of_outputs(
+            outputs_to_check,
+            utils.get_list_of_data(outputs_to_check, Path(test_ops['data_path'][0]).joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/plane{i}")),
+            utils.get_list_of_data(outputs_to_check, Path(test_ops['save_path0']).joinpath(f"suite2p/plane{i}")),
+        ))
 
 
 def test_extraction_output_2plane2chan(test_ops):
@@ -134,9 +135,10 @@ def test_extraction_output_2plane2chan(test_ops):
     ops[1]['meanImg_chan2'] = np.load(detection_dir.joinpath('meanImg_chan2p1.npy'))
     extract_wrapper(ops)
     nplanes = test_ops['nplanes']
-    assert all(utils.check_output(
-        output_root=test_ops['save_path0'],
-        outputs_to_check=['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks'],
-        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes=nplanes
-    ))
+    outputs_to_check = ['F', 'Fneu', 'F_chan2', 'Fneu_chan2', 'stat', 'spks']
+    for i in range(nplanes):
+        assert all(utils.compare_list_of_outputs(
+            outputs_to_check,
+            utils.get_list_of_data(outputs_to_check, Path(test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/plane{i}"))),
+            utils.get_list_of_data(outputs_to_check, Path(test_ops['save_path0']).joinpath(f"suite2p/plane{i}")),
+        ))

--- a/tests/regression/test_extraction_pipeline.py
+++ b/tests/regression/test_extraction_pipeline.py
@@ -26,7 +26,8 @@ def prepare_for_extraction(op, input_file_name_list, dimensions):
     ops = []
     for plane in range(op['nplanes']):
         curr_op = op.copy()
-        plane_dir = utils.get_plane_dir(save_path0=op['save_path0'], plane=plane)
+        plane_dir = Path(op['save_path0']).joinpath(f'suite2p/plane{plane}')
+        plane_dir.mkdir(exist_ok=True, parents=True)
         bin_path = str(plane_dir.joinpath('data.bin'))
         BinaryFile.convert_numpy_file_to_suite2p_binary(str(input_file_name_list[plane][0]), bin_path)
         curr_op['meanImg'] = np.reshape(
@@ -48,7 +49,8 @@ def prepare_for_extraction(op, input_file_name_list, dimensions):
 def extract_wrapper(ops):
     for plane in range(ops[0]['nplanes']):
         curr_op = ops[plane]
-        plane_dir = utils.get_plane_dir(save_path0=curr_op['save_path0'], plane=plane)
+        plane_dir = Path(curr_op['save_path0']).joinpath(f'suite2p/plane{plane}')
+        plane_dir.mkdir(exist_ok=True, parents=True)
         extract_input = np.load(
             curr_op['data_path'][0].joinpath(
                 'detection',

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -8,13 +8,6 @@ import numpy as np
 import suite2p, utils, json
 
 
-def get_outputs_to_check(n_channels):
-    outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat']
-    if n_channels == 2:
-        outputs_to_check.extend(['F_chan2', 'Fneu_chan2'])
-    return outputs_to_check
-
-
 def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     """
     Tests for case with 1 plane and 1 channel with multiple batches. Results are saved to nwb format
@@ -28,7 +21,7 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     suite2p.run_s2p(ops=test_ops)
 
     nplanes = test_ops['nplanes']
-    outputs_to_check = get_outputs_to_check(test_ops['nchannels'])
+    outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat']
     for i in range(nplanes):
         assert all(utils.compare_list_of_outputs(
             outputs_to_check,
@@ -41,11 +34,19 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     stat, ops, F, Fneu, spks, iscell, probcell, redcell, probredcell = \
         io.read_nwb(str(Path(test_ops['save_path0']).joinpath('suite2p/ophys.nwb')))
     output_dir = Path(test_ops['save_path0']).joinpath(f"suite2p/plane0")
-    assert all(utils.compare_list_of_outputs(
-        get_outputs_to_check(test_ops['nchannels']),
-        utils.get_list_of_data(get_outputs_to_check(test_ops['nchannels']), output_dir),
-        [F, Fneu, np.stack([iscell.astype(np.float32), probcell.astype(np.float32)]).T, spks, stat],
-    ))
+    output_name_list = ['F', 'Fneu', 'iscell', 'spks', 'stat']
+    data_list_one = utils.get_list_of_data(output_name_list, output_dir)
+    data_list_two = [F, Fneu, np.stack([iscell.astype(np.float32), probcell.astype(np.float32)]).T, spks, stat]
+    for output, data1, data2 in zip(output_name_list, data_list_one, data_list_two):
+        if output == 'stat':  # where the elements of npy arrays are dictionaries (e.g: stat.npy)
+            for gt_dict, output_dict in zip(data1, data2):
+                for k in gt_dict.keys():
+                    if k not in ["footprint", "std", "overlap"]:  # todo: these both are different from the original; footprint and overlap are different, std key doesn't exist in output_dict.
+                        assert np.allclose(gt_dict[k], output_dict[k], rtol=1e-4, atol=5e-2)
+        elif output == 'iscell':  # just check the first column; are cells/noncells classified the same way?
+            assert np.array_equal(data1[:, 0], data2[:, 0])
+        else:
+            assert np.allclose(data1, data2, rtol=1e-4, atol=5e-2)
 
 
 def test_2plane_2chan_with_batches(test_ops):
@@ -65,7 +66,9 @@ def test_2plane_2chan_with_batches(test_ops):
         nplanes = ops['nplanes']
         suite2p.run_s2p(ops=ops)
 
-        outputs_to_check = get_outputs_to_check(ops['nchannels'])
+        outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat']
+        if ops['nchannels'] == 2:
+            outputs_to_check.extend(['F_chan2', 'Fneu_chan2'])
         for i in range(nplanes):
             assert all(utils.compare_list_of_outputs(
                 outputs_to_check,
@@ -86,7 +89,7 @@ def test_1plane_2chan_sourcery(test_ops):
     })
     suite2p.run_s2p(ops=test_ops)
     nplanes = test_ops['nplanes']
-    outputs_to_check = get_outputs_to_check(test_ops['nchannels'])
+    outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat', 'F_chan2', 'Fneu_chan2']
     for i in range(nplanes):
         assert all(utils.compare_list_of_outputs(
             outputs_to_check,
@@ -109,7 +112,7 @@ def test_mesoscan_2plane_2z(test_ops):
     suite2p.run_s2p(ops=test_ops)
 
     nplanes = test_ops['nplanes'] * test_ops['nrois']
-    outputs_to_check = get_outputs_to_check(test_ops['nchannels'])
+    outputs_to_check = ['F', 'Fneu', 'iscell', 'spks', 'stat']
     for i in range(nplanes):
         assert all(utils.compare_list_of_outputs(
             outputs_to_check,

--- a/tests/regression/test_full_pipeline.py
+++ b/tests/regression/test_full_pipeline.py
@@ -28,12 +28,15 @@ def test_1plane_1chan_with_batches_metrics_and_exported_to_nwb_format(test_ops):
     suite2p.run_s2p(ops=test_ops)
 
     nplanes = test_ops['nplanes']
-    assert all(utils.check_output(
-        output_root=test_ops['save_path0'],
-        outputs_to_check=get_outputs_to_check(test_ops['nchannels']),
-        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/"),
-        nplanes=nplanes,
-    ))
+    outputs_to_check = get_outputs_to_check(test_ops['nchannels'])
+    for i in range(nplanes):
+        assert all(utils.compare_list_of_outputs(
+            outputs_to_check,
+            utils.get_list_of_data(outputs_to_check, test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan1500/suite2p/plane{i}")),
+            utils.get_list_of_data(outputs_to_check, Path(test_ops['save_path0']).joinpath(f"suite2p/plane{i}")),
+        ))
+
+
     # Read Nwb data and make sure it's identical to output data
     stat, ops, F, Fneu, spks, iscell, probcell, redcell, probredcell = \
         io.read_nwb(str(Path(test_ops['save_path0']).joinpath('suite2p/ophys.nwb')))
@@ -61,12 +64,14 @@ def test_2plane_2chan_with_batches(test_ops):
         })
         nplanes = ops['nplanes']
         suite2p.run_s2p(ops=ops)
-        assert all(utils.check_output(
-            output_root=ops['save_path0'],
-            outputs_to_check=get_outputs_to_check(ops['nchannels']),
-            test_data_dir=ops['data_path'][0].joinpath(f"{nplanes}plane{ops['nchannels']}chan1500/suite2p/"),
-            nplanes=nplanes,
-        ))
+
+        outputs_to_check = get_outputs_to_check(ops['nchannels'])
+        for i in range(nplanes):
+            assert all(utils.compare_list_of_outputs(
+                outputs_to_check,
+                utils.get_list_of_data(outputs_to_check, ops['data_path'][0].joinpath(f"{nplanes}plane{ops['nchannels']}chan1500/suite2p/plane{i}")),
+                utils.get_list_of_data(outputs_to_check, Path(ops['save_path0']).joinpath(f"suite2p/plane{i}")),
+            ))
 
 
 def test_1plane_2chan_sourcery(test_ops):
@@ -81,12 +86,13 @@ def test_1plane_2chan_sourcery(test_ops):
     })
     suite2p.run_s2p(ops=test_ops)
     nplanes = test_ops['nplanes']
-    assert all(utils.check_output(
-        output_root=test_ops['save_path0'],
-        outputs_to_check=get_outputs_to_check(test_ops['nchannels']),
-        test_data_dir=test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/"),
-        nplanes=nplanes,
-    ))
+    outputs_to_check = get_outputs_to_check(test_ops['nchannels'])
+    for i in range(nplanes):
+        assert all(utils.compare_list_of_outputs(
+            outputs_to_check,
+            utils.get_list_of_data(outputs_to_check, test_ops['data_path'][0].joinpath(f"{nplanes}plane{test_ops['nchannels']}chan/suite2p/plane{i}")),
+            utils.get_list_of_data(outputs_to_check, Path(test_ops['save_path0']).joinpath(f"suite2p/plane{i}")),
+        ))
 
 
 def test_mesoscan_2plane_2z(test_ops):
@@ -101,10 +107,12 @@ def test_mesoscan_2plane_2z(test_ops):
             test_ops[key] = meso_ops[key]
     test_ops['delete_bin'] = False
     suite2p.run_s2p(ops=test_ops)
-    
-    assert all(utils.check_output(
-        output_root=test_ops['save_path0'],
-        outputs_to_check=get_outputs_to_check(test_ops['nchannels']),
-        test_data_dir=test_ops['data_path'][0].joinpath('suite2p'),
-        nplanes=test_ops['nplanes']*test_ops['nrois'],
-    ))
+
+    nplanes = test_ops['nplanes'] * test_ops['nrois']
+    outputs_to_check = get_outputs_to_check(test_ops['nchannels'])
+    for i in range(nplanes):
+        assert all(utils.compare_list_of_outputs(
+            outputs_to_check,
+            utils.get_list_of_data(outputs_to_check, test_ops['data_path'][0].joinpath(f'suite2p/plane{i}')),
+            utils.get_list_of_data(outputs_to_check, Path(test_ops['save_path0']).joinpath(f"suite2p/plane{i}")),
+        ))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,6 @@
 """Utility functions that can be accessed in tests via the utils fixture below. """
 
 from typing import Iterator
-from pathlib import Path
 from tifffile import imread
 
 import numpy as np
@@ -23,19 +22,6 @@ def get_list_of_data(outputs_to_check, output_dir):
             yield np.concatenate([imread(tif) for tif in glob(str(data_path.joinpath("*.tif")))])
         else:
             yield np.load(str(data_path) + ".npy", allow_pickle=True)
-
-
-def check_output(output_root, outputs_to_check, test_data_dir, nplanes: int) -> Iterator[bool]:
-    """
-    Helper function to check if outputs given by a test are exactly the same
-    as the ground truth outputs.
-    """
-    for i in range(nplanes):
-        yield all(compare_list_of_outputs(
-            outputs_to_check,
-            get_list_of_data(outputs_to_check, Path(test_data_dir).joinpath(f'plane{i}')),
-            get_list_of_data(outputs_to_check, Path(output_root).joinpath(f"suite2p/plane{i}")),
-        ))
 
 
 def compare_list_of_outputs(output_name_list, data_list_one, data_list_two) -> Iterator[bool]:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,13 +9,6 @@ from glob import glob
 
 r_tol, a_tol = 1e-4, 5e-2
 
-
-def get_plane_dir(save_path0: str, plane: int) -> Path:
-    plane_dir = Path(save_path0).joinpath(f'suite2p/plane{plane}')
-    plane_dir.mkdir(exist_ok=True, parents=True)
-    return plane_dir
-
-
 def check_dict_dicts_all_close(first_dict, second_dict) -> Iterator[bool]:
     for gt_dict, output_dict in zip(first_dict, second_dict):
         for k in gt_dict.keys():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,15 +6,8 @@ from tifffile import imread
 import numpy as np
 from glob import glob
 
-r_tol, a_tol = 1e-4, 5e-2
 
-def check_dict_dicts_all_close(first_dict, second_dict) -> Iterator[bool]:
-    for gt_dict, output_dict in zip(first_dict, second_dict):
-        for k in gt_dict.keys():
-            yield np.allclose(gt_dict[k], output_dict[k], rtol=r_tol, atol=a_tol)
-
-
-def get_list_of_data(outputs_to_check, output_dir):
+def get_list_of_data(outputs_to_check, output_dir) -> Iterator[np.ndarray]:
     """Gets list of output data from output_directory."""
     for output in outputs_to_check:
         data_path = output_dir.joinpath(f"{output}")
@@ -27,8 +20,10 @@ def get_list_of_data(outputs_to_check, output_dir):
 def compare_list_of_outputs(output_name_list, data_list_one, data_list_two) -> Iterator[bool]:
     for output, data1, data2 in zip(output_name_list, data_list_one, data_list_two):
         if output == 'stat':  # where the elements of npy arrays are dictionaries (e.g: stat.npy)
-            yield from check_dict_dicts_all_close(data1, data2)
+            for gt_dict, output_dict in zip(data1, data2):
+                for k in gt_dict.keys():
+                    yield np.allclose(gt_dict[k], output_dict[k], rtol=1e-4, atol=5e-2)
         elif output == 'iscell':  # just check the first column; are cells/noncells classified the same way?
             yield np.array_equal(data1[:, 0], data2[:, 0])
         else:
-            yield np.allclose(data1, data2, rtol=r_tol, atol=a_tol)
+            yield np.allclose(data1, data2, rtol=1e-4, atol=5e-2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,7 +27,7 @@ def get_list_of_data(outputs_to_check, output_dir):
 def compare_list_of_outputs(output_name_list, data_list_one, data_list_two) -> Iterator[bool]:
     for output, data1, data2 in zip(output_name_list, data_list_one, data_list_two):
         if output == 'stat':  # where the elements of npy arrays are dictionaries (e.g: stat.npy)
-            yield check_dict_dicts_all_close(data1, data2)
+            yield from check_dict_dicts_all_close(data1, data2)
         elif output == 'iscell':  # just check the first column; are cells/noncells classified the same way?
             yield np.array_equal(data1[:, 0], data2[:, 0])
         else:


### PR DESCRIPTION
Hi,

It's been taking some time to diagnose test failures, and one of the root causes was the many layers of wrapper functions that handle things like data selection and file creation, plus hard-to-read error messages from pytest.  This pull request puts more of the test work into the test functions themselves.  It makes the functions a little longer, but should make it easier to figure out what's happening when something breaks.

Best wishes,

Nick