### PR TITLE
use chan field if exists

### DIFF
--- a/suite2p/io/sbx.py
+++ b/suite2p/io/sbx.py
@@ -26,13 +26,18 @@ def sbx_get_shape(sbxfile):
     info = sbx_get_info(sbxfile)
     fsize = os.path.getsize(sbxfile)
     nrows,ncols = info.sz
-    chan = info.channels
-    if chan == 1:
-        chan = 2; 
-    elif chan == 2:
-        chan = 1
-    elif chan == 3:
-        chan = 1
+    
+    if hasattr(info,'chan'):
+        chan = info.chan.nchan
+    else:
+        chan = info.channels
+        if chan == 1:
+            chan = 2 # both PMT0 & 1
+        elif chan == 2:
+            chan = 1 # PMT 0 
+        elif chan == 3:
+            chan = 1 # PMT 1 
+        
     max_idx = fsize/nrows/ncols/chan/2
     if max_idx != info.config.frames:
         print('SBX filesize doesnt match accompaning MAT [{0},{1}]. Check recording.'.format(


### PR DESCRIPTION
If chan exists in info it already contains the number of channels
I don't understand exactly the other conditions, but anyway, the pull request just aligns better with the official MATLAB code.

https://github.com/vazirilab/neurolabware_scanbox_utils_docs/blob/326dff0883b1861ba499099ed36a5aba4cbefb0f/src/sbxread_all.m#L79