### PR TITLE
Patch: Fix DVC Credentials Error

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -11,4 +11,4 @@
     url = gdrive://0ACw_QYaWTX7mUk9PVA
     gdrive_use_service_account = true
     gdrive_service_account_email = travis4@suite2p-testdata-dvc.iam.gserviceaccount.com
-    gdrive_service_account_p12_file_path = .dvc/creds/suite2p-testdata-dvc-b0d23791539c.p12
+    gdrive_service_account_p12_file_path = creds/suite2p-testdata-dvc-b0d23791539c.p12


### PR DESCRIPTION
This fixes the dvc errors:

```
ERROR: failed to pull data from the cloud - Failed to authenticate GDrive remote: [Errno 2] No such file or directory: 
```

A recent dvc update changed the default path the config file searches from, so the fix was to just change the path to be relative from the .dvc directory.

Best wishes,

Nick