### PR TITLE
Cast numpy.fft.fft2 result to numpy.complex64

### DIFF
--- a/suite2p/registration/utils.py
+++ b/suite2p/registration/utils.py
@@ -202,7 +202,7 @@ def convolve(mov: np.ndarray, img: np.ndarray) -> np.ndarray:
     -------
     convolved_data: nImg x Ly x Lx
     """
-    return ifft2(apply_dotnorm(fft2(mov), img))
+    return ifft2(apply_dotnorm(fft2(mov).astype(np.complex64), img))
 
 
 def complex_fft2(img: np.ndarray, pad_fft: bool = False) -> np.ndarray:


### PR DESCRIPTION
numpy.fft.fft2 returns numpy.complex128 on some systems, which is not going to be accepted as an input type by apply_dotnorm.