### PR TITLE
Remove pyqt from base pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,8 @@ setuptools.setup(
     use_scm_version=True,
     install_requires=['importlib-metadata',
         'natsort',
-        'rastermap>0.1.0',
         'tifffile',
         'scanimage-tiff-reader>=1.4.1',
-        'pyqtgraph',
         'paramiko',
         'numpy>=1.16',
         'numba>=0.43.1',
@@ -48,6 +46,8 @@ setuptools.setup(
         "pyqt5",
         "pyqt5-tools",
         "pyqt5.sip",
+        'pyqtgraph',
+        'rastermap>0.1.0',
       ],
       # Note: Not currently available in pip: use conda to install.
       "mkl": [

--- a/suite2p/__init__.py
+++ b/suite2p/__init__.py
@@ -1,5 +1,4 @@
 from .run_s2p import run_s2p, default_ops
-from .gui import run as run_gui
 from .detection import ROI
 
 


### PR DESCRIPTION
Closes #665 

This removes the gui imports from `__init__.py`, so that suite2p can be installed and used if qt is not present (i.e. batch).  If you wish to have the gui conditionally loaded if packages are available, we could wrap the import in a try/except.  But IMHO its cleaner for those needing the gui to `import suite2p.gui`.