### PR TITLE
comment sbxreader nchannels overwrite

### DIFF
--- a/suite2p/io/sbx.py
+++ b/suite2p/io/sbx.py
@@ -72,7 +72,7 @@ def sbx_to_binary(ops, ndeadcols=-1, ndeadrows=0):
     for ifile,sbxfname in enumerate(sbxlist):
         f = sbx_memmap(sbxfname)
         nplanes = f.shape[1]
-        nchannels = f.shape[2]
+        #nchannels = f.shape[2]
         nframes = f.shape[0]
         iblocks = np.arange(0,nframes,ops1[0]['batch_size'])
         if iblocks[-1] < nframes:


### PR DESCRIPTION
I am not sure what is the correct way to design it. But I found that sometimes I don't want to analyze the red channel. 
If I set nchannels parameter to 1 in ops (and comment the channel overwrite here), I can analyze only the first channel. 

So I think that either the ops parameter should not be overwritten by sbxreader, or that when using sbxreader one can not give those parameters (It is actually very easy to extract them to the gui once a file is selected, and then gray-out those parameters).