### PR TITLE
batch_size default is 500 and not 200

### DIFF
--- a/docs/registration.rst
+++ b/docs/registration.rst
@@ -48,7 +48,7 @@ Registering the frames to the reference image
 
 Once the reference image is obtained, we align each frame to the
 reference image. The frames are registered in batches of size
-``ops['batch_size']`` (default is 200 frames per batch).
+``ops['batch_size']`` (default is 500 frames per batch).
 
 We first perform rigid registration (assuming that the whole image
 shifts by some (dy,dx)), and then optionally after that we perform

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -84,7 +84,7 @@ Registration
 - **nimg_init**: (*int, default: 200*) how many frames to use to
   compute reference image for registration
 
-- **batch_size**: (*int, default: 200*) how many frames to register
+- **batch_size**: (*int, default: 500*) how many frames to register
   simultaneously in each batch. This depends on memory constraints - it
   will be faster to run if the batch is larger, but it will require
   more RAM.


### PR DESCRIPTION
If I understand correctly the default batch_size is 500 and not 200:
https://github.com/MouseLand/suite2p/blob/12dc119ac0c7c4355e9cd3e07bebc447755623e4/suite2p/run_s2p.py#L76