### PR TITLE
Red Cell button for GUI

### DIFF
--- a/suite2p/gui/gui2p.py
+++ b/suite2p/gui/gui2p.py
@@ -398,7 +398,13 @@ class MainWindow(QMainWindow):
                 elif event.key() == QtCore.Qt.Key_Up:
                     masks.flip_plot(self)
                     self.ROI_remove()
-
+                    
+                elif event.key() == QtCore.Qt.Key_C:
+                    if self.hasred:
+                        self.redcell[self.ichosen] = ~self.redcell[self.ichosen]
+                        self.imerge = [self.ichosen]
+                        masks.flip_redcell(self)
+                        print('switched red')
 
     def update_plot(self):
         if self.ops_plot['color'] == 7:

--- a/suite2p/gui/masks.py
+++ b/suite2p/gui/masks.py
@@ -177,7 +177,19 @@ def flip_plot(parent):
             raise FileNotFoundError("Unable to find `iscell.npy` file")
 
     io.save_iscell(parent)
-
+    
+def flip_redcell(parent):
+    chan2_masks(parent)
+    parent.update_plot()
+    # Check if `redcell.npy` file exists
+    if not Path(parent.basename).joinpath("redcell.npy").exists():
+        # Try the `plane0` folder in case of NWB file loaded
+        if Path(parent.basename).joinpath("plane0", "redcell.npy").exists():
+            parent.basename = str(Path(parent.basename).joinpath("plane0"))
+        else:
+            raise FileNotFoundError("Unable to find `redcell.npy` file")
+    io.save_redcell(parent)
+      
 def chan2_prob(parent):
     chan2prob = float(parent.chan2edit.text())
     if abs(parent.chan2prob - chan2prob) > 1e-3:


### PR DESCRIPTION
Added keyboard shortcut to change from red cell to not red cell by pressing C in the GUI.  Added function `flip_redcell` to masks.py which implements the change, which is called within `keyPressEvent` in gui2p.py.  `flip_redcell` updates the GUI to change the selected cell to red, and updates redcell.npy accordingly. Pressing C again on a cell marked as red flips the color, "deselecting" the cell, and again updates redcell.npy.  