### PR TITLE
fixing cellpose_overlap function in chan2detect

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,4 +27,4 @@ dependencies:
     - paramiko
     - pynwb
     - sbxreader
-    - suite2p
+    - ipykernel

--- a/environment.yml
+++ b/environment.yml
@@ -27,4 +27,4 @@ dependencies:
     - paramiko
     - pynwb
     - sbxreader
-    - ipykernel
+    - suite2p

--- a/suite2p/detection/chan2detect.py
+++ b/suite2p/detection/chan2detect.py
@@ -73,14 +73,14 @@ def cellpose_overlap(stats, mimg2):
     from . import anatomical 
     masks = anatomical.roi_detect(mimg2)[0]
     Ly, Lx = masks.shape
-    redstats = np.zeros(len(stats), np.float32)
+    redstats = np.zeros((len(stats),2), np.float32) #changed the size of preallocated space
     for i in range(len(stats)):
         smask = np.zeros((Ly, Lx), np.uint16)
         ypix0, xpix0= stats[i]['ypix'], stats[i]['xpix']
         smask[ypix0, xpix0] = 1
         ious = utils.mask_ious(masks, smask)[0]
         iou = ious.max()
-        redstats[i] = np.array([iou>0.5, iou])
+        redstats[i,] = np.array([iou>0.5, iou]) #this had the wrong dimension
     return redstats
 
 def detect(ops, stats):


### PR DESCRIPTION
Hi people,
as described in #695 and #755 suite2p encountered an error after actually running cellpose.
The error message 'ERROR importing or running cellpose, continuing without anatomical estimates' is misleading, because cellpose actually runs nicely. There is merely a simple dimension error in chan2detect causing the upstream 'try' statement in the detect function. Hope the change fixes it.
Best
Uwe