### PR TITLE
Bug fixing in from_stat_dict in \detection\stats.py

### DIFF
--- a/suite2p/detection/stats.py
+++ b/suite2p/detection/stats.py
@@ -60,7 +60,7 @@ class ROI:
 
     @classmethod
     def from_stat_dict(cls, stat: Dict[str, Any]) -> ROI:
-        return cls(ypix=stat['ypix'], xpix=stat['xpix'], lam=stat['lam'])
+        return cls(ypix=stat['ypix'], xpix=stat['xpix'], lam=stat['lam'], med=stat['med'], do_crop=False)
 
     def to_array(self, Ly: int, Lx: int) -> np.ndarray:
         """Returns a 2D boolean array of shape (Ly x Lx) indicating where the roi is located."""


### PR DESCRIPTION
I believe it's a bug that from_stat_dict in ROI class fails to provide adequate arguments for class init (though they might not be needed in the later computation). I tried to update that line.

Before fixing, when using suite2p.ROI.stats_dicts_to_3d_array to generate ROI visualization it will give:

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [5], in <cell line: 1>()
----> 1 im = suite2p.ROI.stats_dicts_to_3d_array(stats,  Ly=output_op['Ly'], Lx=output_op['Lx'], label_id=True)
      2 im[im == 0] = np.nan
      4 plt.figure(figsize = (15,3))

File ~\Anaconda3\envs\suite2p\lib\site-packages\suite2p\detection\stats.py:86, in ROI.stats_dicts_to_3d_array(cls, stats, Ly, Lx, label_id)
     84 arrays = []
     85 for i, stat in enumerate(stats):
---> 86     array = cls.from_stat_dict(stat=stat).to_array(Ly=Ly, Lx=Lx)
     87     if label_id:
     88         array *= i + 1

File ~\Anaconda3\envs\suite2p\lib\site-packages\suite2p\detection\stats.py:63, in ROI.from_stat_dict(cls, stat)
     61 @classmethod
     62 def from_stat_dict(cls, stat: Dict[str, Any]) -> ROI:
---> 63     return cls(ypix=stat['ypix'], xpix=stat['xpix'], lam=stat['lam'])

TypeError: __init__() missing 2 required positional arguments: 'med' and 'do_crop'