### PR TITLE
:bug: Improving the compatibility of saving TIF files

### DIFF
--- a/suite2p/io/tiff.py
+++ b/suite2p/io/tiff.py
@@ -75,8 +75,8 @@ def save_tiff(mov: np.ndarray, fname: str) -> None:
 
     """
     with TiffWriter(fname) as tif:
-        for frame in np.floor(mov).astype(np.int16):
-            tif.write(frame)
+        tif.write(np.floor(mov).astype(np.int16))
+            
 
 
 def open_tiff(file: str,


### PR DESCRIPTION
I think the code for saving tiff can be modified to improve compatibility with other software
The current issue is that the registration tifs exported by suite2p cannot be directly read by the denoising software [DeepCad-RT ](https://github.com/cabooster/DeepCAD-RT) just using tifffile.imread

```python
from tifffile import imread, TiffFile, TiffWriter
import numpy as np


fname = 'temp_suie2p.tif'

# write a tiff file: suite2p methods
mov = imread(r"./file_00001_ch1.tif")
with TiffWriter(fname) as tif:
        for frame in np.floor(mov).astype(np.int16):
            tif.write(frame)


# read the tiff file: by imread
re_read = imread( 'temp_suie2p.tif')
print(re_read.shape)  # (512, 512)

# read the tiff file: by TiffFile
tif = TiffFile(fname)

image = tif.asarray()
print(image.shape) # (512, 512)

print(len(tif.series)) #  100
image = np.array([series.asarray() for series in tif.series])
print(image.shape) # (100, 512, 512)

print(len(tif.pages)) # 100
image = np.array([page.asarray() for page in tif.pages])
print(image.shape) # (100, 512, 512)
```

I think you can abandon the loop and write the whole mov directly by tif.write
```python
from tifffile import imread, TiffFile, TiffWriter
import numpy as np

fname = 'temp_suie2p.tif'

# write a tiff file: modified from suite2p
mov = imread(r"./file_00001_ch1.tif")
with TiffWriter(fname) as tif:
        tif.write(np.floor(mov).astype(np.int16))

# read the tiff file: by imread
re_read = imread( 'temp_suie2p.tif')
print(re_read.shape)  # (100, 512, 512)


# read the tiff file: by TiffFile
tif =TiffFile(fname)

image = tif.asarray()
print(image.shape) # (100, 512, 512)

print(len(tif.series)) #  1
image = np.array([series.asarray() for series in tif.series])
print(image.shape) # (1, 100, 512, 512)

print(len(tif.pages)) # 100
image = np.array([page.asarray() for page in tif.pages])
print(image.shape) # (100, 512, 512)
```

That is because tifffile.imwrite writes a new series to the file.
ref: https://github.com/cgohlke/tifffile/issues/104