### PR TITLE
Re-add connected to GUI options

### DIFF
--- a/suite2p/gui/rungui.py
+++ b/suite2p/gui/rungui.py
@@ -119,8 +119,9 @@ class RunWindow(QDialog):
         nrkeys = [["nonrigid", "block_size", "snr_thresh", "maxregshiftNR"],
                   ["1Preg", "spatial_hp_reg", "pre_smooth", "spatial_taper"]]
         cellkeys = [
-            "roidetect", "sparse_mode", "denoise", "spatial_scale", "threshold_scaling",
-            "max_overlap", "max_iterations", "high_pass", "spatial_hp_detect"
+            "roidetect", "sparse_mode", "denoise", "spatial_scale", "connected",
+            "threshold_scaling", "max_overlap", "max_iterations", "high_pass",
+            "spatial_hp_detect"
         ]
         anatkeys = [
             "anatomical_only", "diameter", "cellprob_threshold", "flow_threshold",
@@ -177,6 +178,7 @@ class RunWindow(QDialog):
             "if 1, run sparse_mode cell detection",
             "if 1, run PCA denoising on binned movie to improve cell detection",
             "choose size of ROIs: 0 = multi-scale; 1 = 6 pixels, 2 = 12, 3 = 24, 4 = 48",
+            "whether or not to require ROIs to be fully connected (set to 0 for dendrites/boutons)",
             "adjust the automatically determined threshold for finding ROIs by this scalar multiplier",
             "ROIs with greater than this overlap as a fraction of total pixels will be discarded",
             "maximum number of iterations for ROI detection",


### PR DESCRIPTION
Hi! I noticed that "connected" was dropped from the GUI menu even though it's still in the docs. This seems to be related to https://github.com/MouseLand/suite2p/issues/954 since sparse_mode and connected were both removed in the same commit here f2fd46be09ecb888790bdb8d5cda7b4023a99fd4.

In any case, I wanted the option back, so this is a PR to do that, in case anyone else does too :) 