### PR TITLE
Update installation instructions for Macs, min version of rastermap

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ pip install --upgrade suite2p
 ~~~~
 
 ### Installation for Macs with Apple Silicon chips (e.g., M1)
-1. Download an iTerm2 terminal from this [link](https://iterm2.com/). Install it into your /Applications folder. If you already have downloaded iTerm, duplicate it and give it whatever name you'd like (e.g., "iterm2Rosetta"). 
-2. Navigate to the iTerm app you will use, right click it, and then select "Get Info". Check "Open using Rosetta". 
-3. Open up this iTerm app and follow steps 1 & 2 in the installation section [above](#installation_section) to install anaconda.
+1. Follow steps 1 & 2 in the installation section [above](#installation_section) to install anaconda.
 4. Use the following command `CONDA_SUBDIR=osx-64 conda create --name suite2p python=3.8`
 5. Follow steps 4-7 in the installation section [above](#installation_section) to install the `suite2p` package. 
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Pachitariu, M., Stringer, C., Schröder, S., Dipoppa, M., Rossi, L. F., Carandin
 
 For additional dependencies, like h5py, NWB, Scanbox, and server job support, use the command `python -m pip install suite2p[io]`.
 
-If you are running suite2p on Windows or Linux we recommend installing ScanImage Tiff Reader with `pip install scanimage-tiff-reader` (this package is no longer supported on Mac, but may be supported again in the near future, we will change the instructions accordingly if so).
+We recommend installing ScanImage Tiff Reader with `pip install scanimage-tiff-reader`.
 
 If you have an older `suite2p` environment you can remove it with `conda env remove -n suite2p` before creating a new one.
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 install_deps = ["importlib-metadata",
         "natsort",
-        "rastermap>0.1.0,<=0.1.3",
+        "rastermap>=0.9.0",
         "tifffile",
         "torch>=1.13.1",
         "numpy>=1.24.3",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 install_deps = ["importlib-metadata",
         "natsort",
-        "rastermap>0.1.0",
+        "rastermap>0.1.0,<=0.1.3",
         "tifffile",
         "torch>=1.13.1",
         "numpy>=1.24.3",


### PR DESCRIPTION
1. By setting the env var `CONDA_SUBDIR=osx-64`, I think that using iTerm with Rosetta is no longer needed. Without it, I was able to `pip install "suite2p[all]"` on my Mac M1 and run it with images in an h5 file (an nwb file) just fine. So I simplified the instructions for Mac M1 machines. 

2. I reverted the note about scanimage-tiff-reader mac incompatibility. The latest release 1.4.1.4 adds support for Mac M1. See https://gitlab.com/vidriotech/scanimagetiffreader-python/-/commit/9f4de14aa3186b0643608c5d203890f2ca1a8172 .  I don't know if there was a separate issue with non-M1 macs, but I could install suite2p on both a Mac with Apple Silicon and one with an Intel processor. Fix #981.

3. I updated the minimum version of rastermap to one that supports `from rastermap.rastermap import Rastermap`

4. My editor removes trailing spaces at the end of lines automatically...