### PR TITLE
checking h5py key to open binaries before data_path

### DIFF
--- a/suite2p/io/utils.py
+++ b/suite2p/io/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer and Marius Pachitariu.
+Copright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer and Marius Pachitariu.
 """
 import glob
 import os
@@ -227,18 +227,16 @@ def find_files_open_binaries(ops1, ish5=False):
         input_format = "h5"
     print(input_format)
     if input_format == "h5":
-        if len(ops1[0]["data_path"]) > 0:
-            fs, ops2 = get_h5_list(ops1[0])
-            print("NOTE: using a list of h5 files:")
-            print(fs)
-        # find h5"s
+        if ops1[0]["h5py]"]:
+            fs = ops1[0]["h5py"]
         else:
-            if ops1[0]["look_one_level_down"]:
-                fs = list_h5(ops1[0])
+            if len(ops1[0]["data_path"]) > 0:
+                fs, ops2 = get_h5_list(ops1[0])
                 print("NOTE: using a list of h5 files:")
                 print(fs)
+            # find h5"s
             else:
-                fs = [ops1[0]["h5py"]]
+                raise Exception("No h5 files found")
     elif input_format == "sbx":
         # find sbx
         fs, ops2 = get_sbx_list(ops1[0])

--- a/suite2p/io/utils.py
+++ b/suite2p/io/utils.py
@@ -227,7 +227,7 @@ def find_files_open_binaries(ops1, ish5=False):
         input_format = "h5"
     print(input_format)
     if input_format == "h5":
-        if ops1[0]["h5py]"]:
+        if ops1[0]["h5py"]:
             fs = ops1[0]["h5py"]
         else:
             if len(ops1[0]["data_path"]) > 0:

--- a/suite2p/io/utils.py
+++ b/suite2p/io/utils.py
@@ -227,6 +227,7 @@ def find_files_open_binaries(ops1, ish5=False):
         input_format = "h5"
     print(input_format)
     if input_format == "h5":
+        print(f"OPS1 h5py: {ops1[0]['h5py']}")
         if ops1[0]["h5py"]:
             fs = ops1[0]["h5py"]
         else:


### PR DESCRIPTION
Hello, In the default_ops, it states that if a h5py contains elements to process that data_path will not be checked. To fix this, I re-ordered the logic in the io.utils.find_files_open_binaries so that the h5py is checked first and bypasses the data_path search. This PR is linked to an issue I opened just now. Thanks!

https://github.com/MouseLand/suite2p/issues/1041 