### PR TITLE
Fix use of dataclasses for python 3.11

### DIFF
--- a/suite2p/detection/stats.py
+++ b/suite2p/detection/stats.py
@@ -56,7 +56,7 @@ class ROI:
     lam: np.ndarray
     med: np.ndarray
     do_crop: bool
-    rsort: np.ndarray = field(default=np.sort(distance_kernel(radius=30).flatten()),
+    rsort: np.ndarray = field(default_factory=lambda: np.sort(distance_kernel(radius=30).flatten()),
                               repr=False)
 
     def __post_init__(self):


### PR DESCRIPTION
Suite2p is currently non-functional in Python 3.11 due to a change in the way the built-in library `dataclasses` handles default values: https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses (cross ref #1029 )

This change modifies the default creation in two ways to address the limitation:
* rather than directly assigning a (mutable) `default`, a default is generated independently in each instance by defining a `default_factory` instead
* `default_factory` expects a function that will be called on `ROI.__init__()`, so move default generation to a lambda expression to be called as and when needed. Depending on style preferences, this could potentially be integrated with the `suite2p.detection.distance_kernel` method directly, since as far as I can tell the default in the `ROI` dataclass is the sole purpose of that function.

The new method is back-compatible at least as far as Python 3.8.

I have not tested for any other 3.11 incompatibilities yet