### PR TITLE
Qt6 CheckState Fix for Windows Users 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to download and edit the code, and use that version,
 ### Installation for developers
 
 1. Clone the repository and `cd suite2p` in an anaconda prompt / command prompt with `conda` for **python 3** in the path
-2. Run `conda env create --name suite2p`
+2. Run `conda create --name suite2p python=3.9`
 3. To activate this new environment, run `conda activate suite2p` (you will have to activate every time you want to run suite2p)
 4. Install the local version of suite2p into this environment in develop mode with the command `pip install -e .[all]`
 5. Run tests: `python setup.py test` or `pytest -vs`, this will automatically download the test data into your `suite2p` folder. The test data is split into two parts: test inputs and expected test outputs which will be downloaded in `data/test_inputs` and `data/test_outputs` respectively. The .zip files for these two parts can be downloaded from these links: [test_inputs](https://www.suite2p.org/static/test_data/test_inputs.zip) and [test_outputs](https://www.suite2p.org/static/test_data/test_outputs.zip).

--- a/suite2p/gui/gui2p.py
+++ b/suite2p/gui/gui2p.py
@@ -208,7 +208,7 @@ class MainWindow(QMainWindow):
         return b0
 
     def roi_text(self, state):
-        if state == QtCore.Qt.Checked:
+        if QtCore.Qt.CheckState(state) == QtCore.Qt.Checked:
             for n in range(len(self.roi_text_labels)):
                 if self.iscell[n] == 1:
                     self.p1.addItem(self.roi_text_labels[n])
@@ -232,7 +232,7 @@ class MainWindow(QMainWindow):
 
     def zoom_cell(self, state):
         if self.loaded:
-            if state == QtCore.Qt.Checked:
+            if QtCore.Qt.CheckState(state) == QtCore.Qt.Checked:
                 self.zoomtocell = True
             else:
                 self.zoomtocell = False
@@ -554,7 +554,7 @@ class MainWindow(QMainWindow):
             self.show()
 
     def ROIs_on(self, state):
-        if state == QtCore.Qt.Checked:
+        if QtCore.Qt.CheckState(state) == QtCore.Qt.Checked:
             self.ops_plot["ROIs_on"] = True
             self.p1.addItem(self.color1)
             self.p2.addItem(self.color2)


### PR DESCRIPTION
- Fixes a bug where the graphics scene is lost when toggling a few settings due to the way the "state" is handled by Qt6. 
- Also fixes the environment creation statement for developers in the README