### PR TITLE
force integer value for `np.arange` when indexing h5 file with 4D and 5D data

### DIFF
--- a/suite2p/io/h5.py
+++ b/suite2p/io/h5.py
@@ -74,7 +74,7 @@ def h5py_to_binary(ops):
                         im = f[key][irange, :, :]
                     else:
                         irange = np.arange(
-                            ik / ncp, min(ik / ncp + nbatch / ncp, nframes_all / ncp),
+                            int(ik / ncp), int(min(ik / ncp + nbatch / ncp, nframes_all / ncp)),
                             1)
                         if irange.size == 0:
                             break


### PR DESCRIPTION
This pull request is related to Issue #1111 .
Force division values to int, so indexing can be done using integer values. 