### PR TITLE
Fix File Path Handling for Usernames with Spaces

### DIFF
--- a/suite2p/gui/rungui.py
+++ b/suite2p/gui/rungui.py
@@ -448,12 +448,9 @@ class RunWindow(QDialog):
         self.db = np.load(db_file, allow_pickle=True).item()
         print(self.db)
         print("Running suite2p with command:")
-        cmd = f"-u -W ignore -m suite2p --ops {ops_file} --db {db_file}"
-        print("python " + cmd)
-        self.process.start(sys.executable, cmd.split(" "))
-
-        #self.process.start('python -u -W ignore -m suite2p --ops "%s" --db "%s"' %
-        #                   (ops_file, db_file))
+        cmd = ['-u', '-W', 'ignore', '-m', 'suite2p', '--ops', ops_file, '--db', db_file]
+        print("python " + " ".join(f'"{arg}"' if ' ' in arg else arg for arg in cmd))
+        self.process.start(sys.executable, cmd)
 
     def stop(self):
         self.finish = False


### PR DESCRIPTION
There is a recurring issue: users whose usernames contain spaces cannot use the GUI, because `rungui.py` does not correctly handle spaces in the paths for ops and db. As we are starting to use Suite2p recently, many people in the lab have encountered this issue.

Many related issues ([#662](https://github.com/MouseLand/suite2p/issues/662), [#1066](https://github.com/MouseLand/suite2p/issues/1066), [#1141](https://github.com/MouseLand/suite2p/issues/1141)) have been reported and subsequently closed, often suggesting workarounds such as manual code edits or creating a new user account. However, I believe this could be addressed more directly in the code.

It would be greatly appreciated if this could be looked into to improve the experience for users, without requiring complex workarounds.