### PR TITLE
Fix mutable default value in suite2p.detection.stats.py

### DIFF
--- a/suite2p/detection/stats.py
+++ b/suite2p/detection/stats.py
@@ -56,8 +56,7 @@ class ROI:
     lam: np.ndarray
     med: np.ndarray
     do_crop: bool
-    rsort: np.ndarray = field(default=np.sort(distance_kernel(radius=30).flatten()),
-                              repr=False)
+    rsort: np.ndarray = field(default_factory=lambda: np.sort(distance_kernel(radius=30).flatten()), repr=False)
 
     def __post_init__(self):
         """Validate inputs."""


### PR DESCRIPTION
**Summary**

This PR updates the `rsort` field definitions in `suite2p/detection/stats.py` to replace mutable default values with `default_factory`. As of Python 3.12, `dataclass` enforces that default fields cannot be mutable type, so it is not currently possible to run suite2p in Python 3.12 or newer.  Implementing this change ensures compatibility with Python 3.12 and prevents unintended shared state across instances.

**Changes**

Updated `rsort` in `suite2p/detection/stats.py` to use `default_factory = lambda: np.sort(distance_kernel(radius=30).flatten())` instead of `default=np.sort(distance_kernel(radius=30).flatten())`.

Verified compatibility with Python 3.12, which now enforces stricter checks on mutable defaults.

**Reasoning**

Python 3.12 introduced a stricter enforcement of mutable defaults in dataclass fields, raising a `ValueError` when using a mutable default directly. This fix ensures proper instance-level initialization while maintaining the intended behavior.

**Testing**

Verified that the updated implementation runs correctly without `ValueError` in Python 3.12.