### PR TITLE
Fix for crash with single-channel multi-plane data

### DIFF
--- a/suite2p/io/save.py
+++ b/suite2p/io/save.py
@@ -178,7 +178,6 @@ def combined(save_folder, save=True):
                 redcell = np.concatenate((redcell, redcell0))
         ii += 1
         print("appended plane %d to combined view" % k)
-    print(meanImg_chan2.shape)
     ops["meanImg"] = meanImg
     ops["meanImgE"] = meanImgE
     if ops["nchannels"] > 1:


### PR DESCRIPTION
A print statement on an uninitialized variable causes combine to crash for multi plane data with a single channel. Simply removing the print statement should fix it.

Closes: #1193 