### PR TITLE
Restore `default_ops` in `suite2p` module?

### DIFF
--- a/suite2p/__init__.py
+++ b/suite2p/__init__.py
@@ -3,6 +3,7 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 """
 from suite2p.version import version, version_str
 from suite2p.parameters import default_settings, user_settings, SETTINGS_FOLDER, default_db
+from suite2p.default_ops import default_ops
 from suite2p.pipeline_s2p import pipeline
 from suite2p.run_s2p import run_s2p, run_plane
 from suite2p.detection import detection_wrapper

--- a/suite2p/default_ops.py
+++ b/suite2p/default_ops.py
@@ -2,9 +2,10 @@
 Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer and Marius Pachitariu.
 """
 from .version import version
+from typing import Dict, Any
 
 
-def default_ops():
+def _default_ops():
     """ default options to run pipeline """
     return {
         # Suite2p version
@@ -163,3 +164,11 @@ def default_ops():
         "prctile_baseline": 8.,  # optional (whether to use a percentile baseline)
         "neucoeff": 0.7,  # neuropil coefficient
     }
+
+def default_ops() -> Dict[str, Any]:
+    """ default options to run pipeline, spoofs the 
+     old default_ops dict but merges it in with `default_settings`
+     where there are shared keys """
+    from suite2p import default_settings
+
+    return {**_default_ops(), **default_settings()}

--- a/suite2p/registration/register.py
+++ b/suite2p/registration/register.py
@@ -801,15 +801,15 @@ def assign_reg_io(f_reg, f_raw=None, f_reg_chan2=None,
         Tiff output directory for the alternate channel.
     """
     if f_reg_chan2 is None or not align_by_chan2:
-        f_align_in = f_reg if not f_raw else f_raw
-        f_alt_in = f_reg_chan2 if not f_raw_chan2 else f_raw_chan2
-        f_align_out = f_reg if f_raw else None
-        f_alt_out = f_reg_chan2 if f_raw_chan2 else None
+        f_align_in = f_reg if f_raw is None else f_raw
+        f_alt_in = f_reg_chan2 if f_raw_chan2 is None else f_raw_chan2
+        f_align_out = f_reg if f_raw is not None else None
+        f_alt_out = f_reg_chan2 if f_raw_chan2 is not None else None
     else:
-        f_align_in = f_reg_chan2 if not f_raw_chan2 else f_raw_chan2
-        f_alt_in = f_reg if not f_raw else f_raw
-        f_align_out  = f_reg_chan2 if f_raw_chan2 else None
-        f_alt_out = f_reg if f_raw else None
+        f_align_in = f_reg_chan2 if f_raw_chan2 is None else f_raw_chan2
+        f_alt_in = f_reg if f_raw is None else f_raw
+        f_align_out  = f_reg_chan2 if f_raw_chan2 is not None else None
+        f_alt_out = f_reg if f_raw is not None else None
 
     if f_alt_in is not None:
         if f_align_in.shape[0] != f_alt_in.shape[0]:


### PR DESCRIPTION
One test (`run_pipeline.py`) and probably a lot of other-user code that has used `suite2p` programmatically use the `default_ops` function to populate settings (and then tweak args from there). From quickly looking at the more recent changes to the code, it looks like there's a migration to `default_settings`, which (as far as I can tell) contains the same info just derived from an internal dict with additional information for the GUI, presumably to keep it all in one place? I was curious if there's a reason not to make `default_ops` accessible the way it was before `from suite2p import default_ops` so that old code doesn't break when a user updates their `suite2p`? I get that it's dangerous to have two dicts floating around that might disagree on parameters, so I made `default_ops()` return `{**_default_ops(), **default_settings()}` so that `default_settings` always tracks the important variables.