### PR TITLE
Fix assign_reg_io for ndarray input

### DIFF
--- a/suite2p/registration/register.py
+++ b/suite2p/registration/register.py
@@ -801,22 +801,22 @@ def assign_reg_io(f_reg, f_raw=None, f_reg_chan2=None,
         Tiff output directory for the alternate channel.
     """
     if f_reg_chan2 is None or not align_by_chan2:
-        f_align_in = f_reg if not f_raw else f_raw
-        f_alt_in = f_reg_chan2 if not f_raw_chan2 else f_raw_chan2
-        f_align_out = f_reg if f_raw else None
-        f_alt_out = f_reg_chan2 if f_raw_chan2 else None
+        f_align_in = f_reg if f_raw is None else f_raw
+        f_alt_in = f_reg_chan2 if f_raw_chan2 is None else f_raw_chan2
+        f_align_out = f_reg if f_raw is not None else None
+        f_alt_out = f_reg_chan2 if f_raw_chan2 is not None else None
     else:
-        f_align_in = f_reg_chan2 if not f_raw_chan2 else f_raw_chan2
-        f_alt_in = f_reg if not f_raw else f_raw
-        f_align_out  = f_reg_chan2 if f_raw_chan2 else None
-        f_alt_out = f_reg if f_raw else None
+        f_align_in = f_reg_chan2 if f_raw_chan2 is None else f_raw_chan2
+        f_alt_in = f_reg if f_raw is None else f_raw
+        f_align_out = f_reg_chan2 if f_raw_chan2 is not None else None
+        f_alt_out = f_reg if f_raw is not None else None
 
     if f_alt_in is not None:
         if f_align_in.shape[0] != f_alt_in.shape[0]:
             raise ValueError("number of frames in f_align_in and f_alt_in must match")
         
+    tif_root_align, tif_root_alt = None, None
     if save_path:
-        tif_root_align, tif_root_alt = None, None
         if reg_tif:
             tifroot = os.path.join(save_path, "reg_tif")
             os.makedirs(tifroot, exist_ok=True)


### PR DESCRIPTION
I ran into this when trying to use `registration_wrapper` by itself in another project. `registration_wrapper` and its subroutine `assign_reg_io` are documented to take either `BinaryFile`s or `np.ndarray`s, but currently passing an `ndarray` gives the error "The truth value of an array with more than one element is ambiguous" due to trying to test the truth value of the input directly. This is fixed by changing each check to `is None` or `is not None`.