### PR TITLE
Don't force int16 conversion in nonrigid.transform_data

### DIFF
--- a/suite2p/registration/nonrigid.py
+++ b/suite2p/registration/nonrigid.py
@@ -461,4 +461,4 @@ def transform_data(data, nblocks, xblock, yblock, ymax1, xmax1,
                              mode="bilinear", padding_mode="border", align_corners=True)
         
     
-    return fr_shift.squeeze().short()#.cpu().numpy()
+    return fr_shift.squeeze().to(dtype=data.dtype)

--- a/suite2p/registration/nonrigid.py
+++ b/suite2p/registration/nonrigid.py
@@ -469,4 +469,4 @@ def transform_data(data, nblocks, xblock, yblock, ymax1, xmax1,
                              mode="bilinear", padding_mode="border", align_corners=True)
         
 
-    return fr_shift.squeeze().short()#.cpu().numpy()
+    return fr_shift.squeeze().to(dtype=data.dtype)


### PR DESCRIPTION
This change fixes an integer overflow that I encountered when using `registration_wrapper` on arrays that were not int16 type. Specifically, the values in my data were in the range of uint16, and the cast to int16 (short) type at the end of `transform_data` caused some values to wrap around to very negative int16 values. With this change, the output of `registration_wrapper` will be the same type as the input.

I realize that in other parts of the software, data arrays are expected to be in int16 format, and other features might not be expected to work correctly if this is violated. However, empirically, at least `registration_wrapper` with an input and output memmapped array of another dtype worked fine with this change.