### PR TITLE
Add sync toggle and opposite-view ROI outline

### DIFF
--- a/suite2p/gui/buttons.py
+++ b/suite2p/gui/buttons.py
@@ -101,8 +101,7 @@ class QuadButton(QPushButton):
         parent.p1.setYRange(self.yrange[0], self.yrange[1])
         parent.p2.setXRange(self.xrange[0], self.xrange[1])
         parent.p2.setYRange(self.yrange[0], self.yrange[1])
-        parent.p2.setXLink("plot1")
-        parent.p2.setYLink("plot1")
+        parent.update_roi_view_sync(source_view=parent.p1)
         parent.show()
 
 
@@ -124,20 +123,17 @@ class SizeButton(QPushButton):
         bid = self.bid
         ts = 100
         if bid == 0:
-            parent.p2.linkView(parent.p2.XAxis, view=None)
-            parent.p2.linkView(parent.p2.YAxis, view=None)
             parent.win.ci.layout.setColumnStretchFactor(0, ts)
             parent.win.ci.layout.setColumnStretchFactor(1, 0)
+            parent.update_roi_view_sync(source_view=parent.p2)
         elif bid == 1:
             parent.win.ci.layout.setColumnStretchFactor(0, ts)
             parent.win.ci.layout.setColumnStretchFactor(1, ts)
-            parent.p2.setXLink("plot1")
-            parent.p2.setYLink("plot1")
+            parent.update_roi_view_sync(source_view=parent.p1)
         elif bid == 2:
-            parent.p2.linkView(parent.p2.XAxis, view=None)
-            parent.p2.linkView(parent.p2.YAxis, view=None)
             parent.win.ci.layout.setColumnStretchFactor(0, 0)
             parent.win.ci.layout.setColumnStretchFactor(1, ts)
+            parent.update_roi_view_sync(source_view=parent.p1)
         # only enable selection buttons when not in "both" view
         if bid != 1:
             if parent.ops_plot["color"] != 0:

--- a/suite2p/gui/graphics.py
+++ b/suite2p/gui/graphics.py
@@ -65,10 +65,12 @@ class ViewBox(pg.ViewBox):
                     return
                 else:
                     if ev.button() == QtCore.Qt.RightButton:
-                        if ichosen not in self.parent.imerge:
-                            self.parent.imerge = [ichosen]
-                            self.parent.ichosen = ichosen
+                        self.parent.imerge = [ichosen]
+                        self.parent.ichosen = ichosen
                         masks.flip_plot(self.parent)
+                        self.parent.imerge = []
+                        self.parent.ichosen = -1
+                        self.parent.update_plot()
                     else:
                         merged = False
                         if ev.modifiers() == QtCore.Qt.ShiftModifier or ev.modifiers(

--- a/suite2p/gui/graphics.py
+++ b/suite2p/gui/graphics.py
@@ -39,9 +39,6 @@ class ViewBox(pg.ViewBox):
             self.menu = ViewBoxMenu(self)
         self.name = name
         self.parent = parent
-        if self.name == "plot2":
-            self.setXLink(parent.p1)
-            self.setYLink(parent.p1)
 
         # set state
         self.state["enableMenu"] = enableMenu
@@ -102,8 +99,7 @@ class ViewBox(pg.ViewBox):
     def zoom_plot(self):
         self.setXRange(0, self.parent.ops["Lx"])
         self.setYRange(0, self.parent.ops["Ly"])
-        self.parent.p2.setXLink(self.parent.p1)
-        self.parent.p2.setYLink(self.parent.p1)
+        self.parent.update_roi_view_sync(source_view=self)
         self.parent.show()
 
 

--- a/suite2p/gui/gui2p.py
+++ b/suite2p/gui/gui2p.py
@@ -205,6 +205,17 @@ class MainWindow(QMainWindow):
         self.checkBoxN.setEnabled(False)
         self.l0.addWidget(self.checkBoxN, b0, 18, 1, 2)
 
+        self.checkBoxSync = QCheckBox("sync views")
+        self.checkBoxSync.setStyleSheet("color: white;")
+        self.checkBoxSync.setToolTip(
+            "Synchronize panning and zooming between cell and not-cell views"
+        )
+        self.syncviews = False
+        self._syncing_roi_views = False
+        self._roi_view_sync_connected = False
+        self.checkBoxSync.stateChanged.connect(self.sync_views)
+        self.l0.addWidget(self.checkBoxSync, b0, 21, 1, 3)
+
         return b0
 
     def roi_text(self, state):
@@ -237,6 +248,57 @@ class MainWindow(QMainWindow):
             else:
                 self.zoomtocell = False
             self.update_plot()
+
+    def sync_views(self, state):
+        self.syncviews = QtCore.Qt.CheckState(state) == QtCore.Qt.Checked
+        if self.loaded:
+            self.update_roi_view_sync()
+
+    def _mirror_roi_view_range(self, src, dst, force=False):
+        if self._syncing_roi_views:
+            return
+        if not force and not self.syncviews:
+            return
+
+        self._syncing_roi_views = True
+        try:
+            x_range, y_range = src.viewRange()
+            dst.setRange(xRange=x_range, yRange=y_range, padding=0)
+        finally:
+            self._syncing_roi_views = False
+
+    def update_roi_view_sync(self, source_view=None):
+        if not hasattr(self, "p1") or not hasattr(self, "p2"):
+            return
+        if source_view is None:
+            source_view = self.p1
+
+        self.p1.linkView(self.p1.XAxis, view=None)
+        self.p1.linkView(self.p1.YAxis, view=None)
+        self.p2.linkView(self.p2.XAxis, view=None)
+        self.p2.linkView(self.p2.YAxis, view=None)
+
+        if not self._roi_view_sync_connected:
+            self.p1.sigRangeChanged.connect(
+                lambda *_: self._mirror_roi_view_range(self.p1, self.p2)
+            )
+            self.p2.sigRangeChanged.connect(
+                lambda *_: self._mirror_roi_view_range(self.p2, self.p1)
+            )
+            self._roi_view_sync_connected = True
+
+        if not self.syncviews:
+            self.win.show()
+            self.show()
+            return
+
+        if source_view is self.p2:
+            self._mirror_roi_view_range(self.p2, self.p1, force=True)
+        else:
+            self._mirror_roi_view_range(self.p1, self.p2, force=True)
+
+        self.win.show()
+        self.show()
 
     def make_graphics(self, b0):
         ##### -------- MAIN PLOTTING AREA ---------- ####################

--- a/suite2p/gui/masks.py
+++ b/suite2p/gui/masks.py
@@ -326,13 +326,25 @@ def draw_masks(parent):  #settings, stat, settings_plot, iscell, ichosen):
 
     if view == 0:
         for n in parent.imerge:
+            wplot = int(1 - parent.iscell[n])
             ypix = parent.stat[n]["ypix"].flatten()
             xpix = parent.stat[n]["xpix"].flatten()
             v = (parent.rois["iROI"][wplot][:, ypix, xpix] > -1).sum(axis=0) - 1
             v = 1 - v / 3
             M[wplot] = make_chosen_ROI(M[wplot], ypix, xpix, v)
+            opposite_plot = 1 - wplot
+            ycirc = parent.stat[n]["ycirc"]
+            xcirc = parent.stat[n]["xcirc"]
+            M[opposite_plot] = make_chosen_circle(
+                M[opposite_plot],
+                ycirc,
+                xcirc,
+                np.array([255, 0, 0], dtype=np.uint8),
+                1,
+            )
     else:
         for n in parent.imerge:
+            wplot = int(1 - parent.iscell[n])
             ycirc = parent.stat[n]["ycirc"]
             xcirc = parent.stat[n]["xcirc"]
             ypix = parent.stat[n]["ypix"].flatten()
@@ -341,6 +353,14 @@ def draw_masks(parent):  #settings, stat, settings_plot, iscell, ichosen):
             col = parent.colors["cols"][color, n]
             sat = 1
             M[wplot] = make_chosen_circle(M[wplot], ycirc, xcirc, col, sat)
+            opposite_plot = 1 - wplot
+            M[opposite_plot] = make_chosen_circle(
+                M[opposite_plot],
+                ycirc,
+                xcirc,
+                np.array([255, 0, 0], dtype=np.uint8),
+                1,
+            )
 
     return M[0], M[1]
 


### PR DESCRIPTION
This is a small GUI improvement for manual ROI curation. I kept the change optional and tried to preserve the existing behavior when the sync toggle is disabled.

## Summary

This PR improves manual ROI curation in the GUI by adding an optional sync toggle for the cell and not-cell views.

When enabled, panning and zooming in one ROI view updates the other view. The selected ROI is also shown as an outline in the opposite view, which makes it easier to compare corresponding cell and not-cell regions.

## Changes

- Add a `sync views` checkbox near the ROI view controls.
- Synchronize cell and not-cell view ranges only when the checkbox is enabled.
- Show the selected ROI outline in the opposite view.
- Clear the selected outline after right-click cell/not-cell reassignment.

## Tests

- `python -m compileall suite2p/gui`
- `pytest -vs`
  - 25 passed, 24 warnings

The warnings appear to come from existing dependencies or unrelated non-GUI modules.

## Manual checks

- Loaded suite2p output in the GUI.
- Confirmed sync on/off behavior in both view.
- Confirmed selected ROI outlines appear in the opposite view.
- Confirmed right-click reassignment clears the selected outline.