### PR TITLE
Write channel 2 registered tiffs to reg_tif_chan2

### DIFF
--- a/suite2p/registration/register.py
+++ b/suite2p/registration/register.py
@@ -971,7 +971,7 @@ def registration_wrapper(f_reg, f_raw=None, f_reg_chan2=None, f_raw_chan2=None,
     if nchannels > 1:
         mean_img_alt = shift_frames_and_write(f_alt_in, f_alt_out, settings["batch_size"], yoff, xoff, yoff1,
                                               xoff1, blocks=blocks, bidiphase=bidiphase,
-                                              tif_root=tif_root_align, device=device)
+                                              tif_root=tif_root_alt, device=device)
     else:
         mean_img_alt = None
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -47,6 +47,39 @@ def test_negative_bidiphase_shift_shifts_every_other_line():
     assert np.allclose(shifted, expected)
 
 
+@pytest.mark.parametrize("align_by_chan2", [False, True])
+def test_reg_tif_channels_are_written_to_their_own_directories(tmp_path, align_by_chan2):
+    """Each channel's registered tiffs go to its own directory (issue #1208)."""
+    import tifffile
+    from suite2p.parameters import default_settings
+    from suite2p.registration.register import registration_wrapper
+
+    np.random.seed(0)
+    n_frames, Ly, Lx = 8, 64, 64
+    # the two channels are separated by an order of magnitude so the mean of a
+    # written tiff identifies which channel produced it
+    f_reg = (np.random.rand(n_frames, Ly, Lx) * 20 + 100).astype("int16")
+    f_reg_chan2 = (np.random.rand(n_frames, Ly, Lx) * 20 + 1000).astype("int16")
+
+    settings = default_settings()["registration"]
+    settings["reg_tif"] = True
+    settings["reg_tif_chan2"] = True
+    settings["batch_size"] = n_frames
+    settings["nonrigid"] = False
+
+    registration_wrapper(f_reg, f_reg_chan2=f_reg_chan2, align_by_chan2=align_by_chan2,
+                         save_path=str(tmp_path), settings=settings,
+                         device=torch.device("cpu"))
+
+    chan1_tifs = sorted((tmp_path / "reg_tif").glob("*.tif"))
+    chan2_tifs = sorted((tmp_path / "reg_tif_chan2").glob("*.tif"))
+    assert chan1_tifs, "no tiffs written to reg_tif"
+    assert chan2_tifs, "no tiffs written to reg_tif_chan2"
+
+    assert tifffile.imread(chan1_tifs[0]).mean() < 500, "reg_tif holds channel 2 data"
+    assert tifffile.imread(chan2_tifs[0]).mean() > 500, "reg_tif_chan2 holds channel 1 data"
+
+
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS not available")
 def test_transform_data_mps_cpu_consistency():
     """Test that MPS and CPU code paths in transform_data produce similar results."""


### PR DESCRIPTION
When a two-channel recording is registered with both `reg_tif` and `reg_tif_chan2` enabled, the second channel's tiffs are written into the first channel's directory and overwrite it. The `reg_tif_chan2` folder is created but stays empty, and the tiffs left in `reg_tif` contain channel 2 data.

`assign_reg_io` already computes two separate tiff directories, `tif_root_align` for the alignment channel and `tif_root_alt` for the alternate one, and picks the right folder for each depending on `align_by_chan2`. `registration_wrapper` passes `tif_root_align` to `register_frames`, which is correct, but then passes `tif_root_align` again to the `shift_frames_and_write` call that handles the alternate channel. Both channels therefore write `file 0000.tif` into the same folder, and since the alternate channel is written second it wins. `tif_root_alt` was computed and never used.

The fix passes `tif_root_alt` to the alternate channel write. This also repairs the case where only `reg_tif_chan2` is set, where `tif_root_align` is `None` and the alternate channel silently wrote no tiffs at all. The bug is symmetric under `align_by_chan2`, since the roles of the two folders swap but the wrong variable is used either way.

Tested with a new parametrised case in `tests/test_registration.py`. It runs `registration_wrapper` on an 8 frame 64 by 64 synthetic pair whose two channels differ by an order of magnitude in mean intensity, so the mean of a written tiff identifies which channel produced it, and asserts that each directory holds its own channel. Both parameter values fail on main, one because `reg_tif_chan2` is empty and the other because `reg_tif` holds the wrong channel, and both pass with this change. The rest of the file still passes, 5 passed in total.

Fixes #1208