### PR TITLE
Honor force_sktiff in ome_to_binary

### DIFF
--- a/suite2p/io/tiff.py
+++ b/suite2p/io/tiff.py
@@ -294,9 +294,9 @@ def ome_to_binary(dbs, settings, reg_file, reg_file_chan2):
     dbs : list of dict
         Database dictionaries for each plane. Must contain keys "file_list",
         "first_files", "batch_size", "nplanes", "nchannels", "functional_chan",
-        and optionally "bruker_bidirectional". Updated in-place with "Ly", "Lx",
-        "nframes", "frames_per_file", "frames_per_folder", "meanImg", and
-        "meanImg_chan2".
+        and optionally "force_sktiff" and "bruker_bidirectional". Updated in-place
+        with "Ly", "Lx", "nframes", "frames_per_file", "frames_per_folder",
+        "meanImg", and "meanImg_chan2".
     settings : dict
         Suite2p settings dictionary, saved alongside each plane's database.
     reg_file : list of file objects
@@ -320,7 +320,7 @@ def ome_to_binary(dbs, settings, reg_file, reg_file_chan2):
     fs = dbs[0]["file_list"]
     first_files = dbs[0]["first_files"]
     batch_size = dbs[0]["batch_size"]
-    use_sktiff = not HAS_SCANIMAGE
+    use_sktiff = True if dbs[0].get("force_sktiff", False) else not HAS_SCANIMAGE
 
     fs_Ch1, fs_Ch2 = [], []
     for f in fs:
@@ -341,9 +341,9 @@ def ome_to_binary(dbs, settings, reg_file, reg_file_chan2):
     logger.info(f"nchannels = {nchannels}")
     
     # loop over all tiffs
-    TiffReader = ScanImageTiffReader if HAS_SCANIMAGE else TiffFile
+    TiffReader = TiffFile if use_sktiff else ScanImageTiffReader
     with TiffReader(fs_Ch1[0]) as tif:
-        if HAS_SCANIMAGE:
+        if not use_sktiff:
             n_pages = tif.shape()[0] if len(tif.shape()) > 2 else 1
             shape = tif.shape()[-2:]
         else:
@@ -377,7 +377,7 @@ def ome_to_binary(dbs, settings, reg_file, reg_file_chan2):
         # read tiff
         if n_pages==1:    
             with TiffReader(file) as tif:
-                im = tif.data()  if HAS_SCANIMAGE else tif.pages[0].asarray()
+                im = tif.pages[0].asarray() if use_sktiff else tif.data()
             if im.dtype.type == np.uint16:
                 im = (im // 2)
             im = im.astype(np.int16)
@@ -389,7 +389,7 @@ def ome_to_binary(dbs, settings, reg_file, reg_file_chan2):
             reg_file[ip].write(bytearray(im))
             #gc.collect()
         else:
-            tif, Ltif = open_tiff(file, not HAS_SCANIMAGE)
+            tif, Ltif = open_tiff(file, use_sktiff)
             # keep track of the plane identity of the first frame (channel identity is assumed always 0)
             ix = 0
             while 1:
@@ -414,14 +414,14 @@ def ome_to_binary(dbs, settings, reg_file, reg_file_chan2):
             ip = iplanes[ik]
             if n_pages==1:
                 with TiffReader(file) as tif:
-                    im = tif.data() if HAS_SCANIMAGE else tif.pages[0].asarray()
+                    im = tif.pages[0].asarray() if use_sktiff else tif.data()
                 if im.dtype.type == np.uint16:
                     im = (im // 2)
                 im = im.astype(np.int16)
                 dbs[ip]["meanImg_chan2"] += im.astype(np.float32)
                 reg_file_chan2[ip].write(bytearray(im))
             else:
-                tif, Ltif = open_tiff(file, not HAS_SCANIMAGE)
+                tif, Ltif = open_tiff(file, use_sktiff)
                 ix = 0
                 while 1:
                     im = read_tiff(file, tif, Ltif, ix, batch_size, use_sktiff)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -258,3 +258,76 @@ def test_get_suite2p_path(input_path, expected_path, success):
     else:
         with pytest.raises(FileNotFoundError):
             get_suite2p_path(Path(input_path))
+
+
+class _ExplodingScanImageTiffReader:
+    """Stand-in for ScanImageTiffReader that fails loudly if it is ever used."""
+
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("ScanImageTiffReader was used")
+
+
+def _write_ome_ch1_tiffs(tmp_path, frames):
+    from tifffile import imwrite
+
+    files = []
+    for i, frame in enumerate(frames):
+        path = tmp_path / f"scan_Ch1_{i:04d}.ome.tif"
+        imwrite(str(path), frame)
+        files.append(str(path))
+    return files
+
+
+def _ome_db(tmp_path, files, force_sktiff):
+    save_path = tmp_path / "plane0"
+    save_path.mkdir(exist_ok=True)
+    return {
+        "nplanes": 1,
+        "nchannels": 1,
+        "functional_chan": 1,
+        "file_list": files,
+        "first_files": np.array([i == 0 for i in range(len(files))]),
+        "batch_size": 10,
+        "force_sktiff": force_sktiff,
+        "db_path": str(save_path / "db.npy"),
+        "settings_path": str(save_path / "settings.npy"),
+    }, save_path
+
+
+def test_ome_to_binary_honors_force_sktiff(tmp_path, monkeypatch):
+    """force_sktiff must select the tifffile reader, as it already does in
+    tiff_to_binary. See issue #1250."""
+    from suite2p.io import tiff as tiff_io
+
+    frames = [np.arange(4 * 5, dtype=np.int16).reshape(4, 5) + i for i in range(2)]
+    files = _write_ome_ch1_tiffs(tmp_path, frames)
+
+    monkeypatch.setattr(tiff_io, "HAS_SCANIMAGE", True)
+    monkeypatch.setattr(tiff_io, "ScanImageTiffReader", _ExplodingScanImageTiffReader)
+
+    db, save_path = _ome_db(tmp_path, files, force_sktiff=True)
+    reg_path = save_path / "data.bin"
+    with open(reg_path, "wb") as reg_file:
+        dbs = tiff_io.ome_to_binary([db], {}, [reg_file], [None])
+
+    assert dbs[0]["nframes"] == len(frames)
+    assert (dbs[0]["Ly"], dbs[0]["Lx"]) == frames[0].shape
+    written = np.fromfile(reg_path, np.int16).reshape(len(frames), *frames[0].shape)
+    np.testing.assert_array_equal(written, np.stack(frames))
+
+
+def test_ome_to_binary_defaults_to_scanimage(tmp_path, monkeypatch):
+    """Without force_sktiff, ome_to_binary still prefers ScanImageTiffReader when
+    it is installed."""
+    from suite2p.io import tiff as tiff_io
+
+    frames = [np.zeros((4, 5), dtype=np.int16)]
+    files = _write_ome_ch1_tiffs(tmp_path, frames)
+
+    monkeypatch.setattr(tiff_io, "HAS_SCANIMAGE", True)
+    monkeypatch.setattr(tiff_io, "ScanImageTiffReader", _ExplodingScanImageTiffReader)
+
+    db, save_path = _ome_db(tmp_path, files, force_sktiff=False)
+    with open(save_path / "data.bin", "wb") as reg_file:
+        with pytest.raises(RuntimeError, match="ScanImageTiffReader was used"):
+            tiff_io.ome_to_binary([db], {}, [reg_file], [None])


### PR DESCRIPTION
Fixes #1250.

`ome_to_binary` computed `use_sktiff = not HAS_SCANIMAGE`, ignoring the `force_sktiff` option that the sibling `tiff_to_binary` already honors one function up.

The variable was also dead for the purpose of picking a reader. Every open site re-derived the choice from `HAS_SCANIMAGE` inline instead of consulting `use_sktiff`: the `TiffReader` alias, the page count probe, both single page reads, and both `open_tiff` calls. `use_sktiff` was only ever passed on to `read_tiff`. So even fixing the one assignment would not have changed which reader opened the file, and setting `force_sktiff` had no effect on OME-TIFF imports at all.

This derives `use_sktiff` the way `tiff_to_binary` does and routes every reader selection in the function through it. With `force_sktiff` false the behaviour is bit identical, since `use_sktiff` and `not HAS_SCANIMAGE` agree in that case.

Two tests in `tests/test_io.py`. They generate their own small OME-style TIFFs with `tifffile` and monkeypatch `HAS_SCANIMAGE` and `ScanImageTiffReader`, so they need neither the cached input download nor `ScanImageTiffReader` to be installed. One asserts `force_sktiff=True` reaches tifffile and writes the expected binary, the other asserts the default path still prefers ScanImageTiffReader when it is available, which guards the change in the other direction.

Reverting `suite2p/io/tiff.py` from main makes the first fail with `RuntimeError: ScanImageTiffReader was used`. Both pass after.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
