### PR TITLE
bidiphase.shift: copy the source slice before the overlapping in-place assignment

### DIFF
--- a/suite2p/registration/bidiphase.py
+++ b/suite2p/registration/bidiphase.py
@@ -3,6 +3,7 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 """
 import numpy as np
 from numpy import fft
+import torch
 
 
 def compute(frames: np.ndarray) -> int:
@@ -60,8 +61,16 @@ def shift(frames: np.ndarray, bidiphase: int) -> None:
     frames : np.ndarray
         The input frames with odd lines shifted.
     """
+    # The source and destination slices overlap. numpy makes a temporary copy
+    # for overlapping assignments, but torch.Tensor.copy_ does not, so on a
+    # torch tensor the in-place assignment reads already-overwritten pixels
+    # and corrupts the odd lines. Copy the source first for both array types.
     if bidiphase > 0:
-        frames[:, 1::2, bidiphase:] = frames[:, 1::2, :-bidiphase]
+        src = frames[:, 1::2, :-bidiphase]
+        src = src.clone() if isinstance(frames, torch.Tensor) else src.copy()
+        frames[:, 1::2, bidiphase:] = src
     elif bidiphase < 0:
-        frames[:, 1::2, :bidiphase] = frames[:, 1::2, -bidiphase:]
+        src = frames[:, 1::2, -bidiphase:]
+        src = src.clone() if isinstance(frames, torch.Tensor) else src.copy()
+        frames[:, 1::2, :bidiphase] = src
     return frames


### PR DESCRIPTION
Fixes #1265.

`bidiphase.shift` shifts the odd scan lines with an in-place assignment whose source and destination slices overlap. numpy handles that with a temporary copy; `torch.Tensor.copy_` does not, so since the registration path started passing torch tensors (v1.0.0.1) every odd line was corrupted instead of shifted (with `bidiphase=3`, 34 % of odd-line pixels in `register_frames`' output differ from the intended shift), while the reference image — still shifted through the numpy path in `registration_wrapper` — was correct.

This copies the source slice first (`clone()` for torch, `copy()` for numpy), restoring the numpy semantics for both array types. Verified on 1.1.0 + this patch: `register_frames(..., bidiphase=3)` reproduces the numpy result exactly, for positive and negative offsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7