### PR TITLE
Classifier: keep feature values at the training minimum in the first bin

### DIFF
--- a/suite2p/classification/classifier.py
+++ b/suite2p/classification/classifier.py
@@ -133,7 +133,11 @@ class Classifier:
             x[x < self.grid[0, n]] = self.grid[0, n]
             x[x > self.grid[-1, n]] = self.grid[-1, n]
             x[np.isnan(x)] = self.grid[0, n]
+            # np.digitize(..., right=True) returns 0 for x == grid[0], which after
+            # the -1 would index the *last* bin; clip so values at (or clamped to)
+            # the minimum use the first bin and values at the maximum the last.
             ibin = np.digitize(x, self.grid[:, n], right=True) - 1
+            ibin = np.clip(ibin, 0, self.p.shape[0] - 1)
             logp[:, n] = np.log(self.p[ibin, n] + 1e-6) - np.log(1 - self.p[ibin, n] +
                                                                  1e-6)
         return logp


### PR DESCRIPTION
`Classifier._get_logp` clamps each feature to the training range and bins it with `np.digitize(x, grid, right=True) - 1`. For `x == grid[0]` — every value at or below the training minimum, and NaNs, which are set to `grid[0]` — `digitize` returns 0, so the bin index is -1 and the probability of the *last* bin is used. With the builtin classifier, a ROI whose skew is below the training minimum is scored with the highest-skew bin (P(cell) 0.986 instead of 0.535); `compact` and `npix_norm` wrap the same way.

This clips the bin index to the valid range. On the builtin classifier's own training set 0.4 % of ROIs are at a feature minimum and no 0.5-threshold verdict changes; user-trained classifiers, fit on far fewer ROIs, hit their minima more often. Reproduction: https://github.com/cindykrafft/research-software-audit/blob/main/audits/suite2p/verify/s1_classifier_bins.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7