### PR TITLE
extract_traces: build sparse-mask indices as integer tensors

### DIFF
--- a/suite2p/extraction/extract.py
+++ b/suite2p/extraction/extract.py
@@ -62,7 +62,7 @@ def extract_traces(f_in, cell_masks, neuropil_masks, batch_size=500,
         # create coo tensor of neuropil masks
         ccol_indices = [m for nm in neuropil_masks for m in nm]
         row_indices = [k for k in range(len(neuropil_masks)) for m in neuropil_masks[k]]
-        inds = torch.Tensor([ccol_indices, row_indices]).to(device)
+        inds = torch.tensor([ccol_indices, row_indices], dtype=torch.long, device=device)
         # convert to csc (tried creating csc directly but it was slow)
         nmasks = torch.sparse_coo_tensor(inds, torch.ones(len(row_indices), device=device),
                                          size=(Ly*Lx, ncells))
@@ -71,7 +71,7 @@ def extract_traces(f_in, cell_masks, neuropil_masks, batch_size=500,
     ccol_indices = [m for cm in cell_masks for m in cm[0]]
     row_indices = [k for k in range(len(cell_masks)) for m in cell_masks[k][0]]
     cell_lam = torch.Tensor([l for cm in cell_masks for l in cm[1]]).to(device)
-    inds = torch.Tensor([ccol_indices, row_indices]).to(device)
+    inds = torch.tensor([ccol_indices, row_indices], dtype=torch.long, device=device)
     cmasks = torch.sparse_coo_tensor(inds, cell_lam,
                                      size=(Ly*Lx, ncells))
     cmasks = cmasks.to_sparse_csc()


### PR DESCRIPTION
`extract_traces` creates the pixel/ROI index tensors for the sparse cell and neuropil mask matrices with `torch.Tensor([...])`, i.e. float32, which represents integers exactly only up to 2**24 = 16,777,216 (`torch.Tensor([16777217]).long()` gives 16777216). Flattened pixel indices in fields of view larger than about 4096 × 4096 are therefore rounded to a neighbouring pixel, silently mixing pixels between ROIs. This creates the index tensors as int64 directly; behaviour is unchanged for smaller fields of view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7